### PR TITLE
Improve site UX with global back-to-top button

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1848,3 +1848,17 @@ body {
     grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
   }
 }
+
+/* Back to Top Button */
+.back-to-top {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(20px);
+  transition: opacity 0.3s, visibility 0.3s, transform 0.3s;
+}
+
+.back-to-top.show {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}

--- a/templates/api_test_utility.html
+++ b/templates/api_test_utility.html
@@ -124,7 +124,7 @@
     <!-- Floating Action Buttons -->
     <div class="fixed right-6 bottom-6 space-y-3 z-40">
         <button aria-label="Back to top"
-                class="w-12 h-12 rounded-full flex items-center justify-center bg-gradient-to-r from-accent-purple to-primary-500 text-white shadow-lg transition-all duration-300 opacity-0 invisible hover:from-accent-purple/80 hover:to-primary-500/80 hover:shadow-glow focus:outline-none group"
+                class="back-to-top w-12 h-12 rounded-full flex items-center justify-center bg-gradient-to-r from-accent-purple to-primary-500 text-white shadow-lg transition-all duration-300 hover:from-accent-purple/80 hover:to-primary-500/80 hover:shadow-glow focus:outline-none group"
                 id="backToTop">
             <i class="fas fa-arrow-up group-hover:animate-bounce"></i>
         </button>
@@ -180,20 +180,6 @@
 <script src="{{ url_for('static', filename='js/api_test_utility.js') }}" type="module"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
-        // Back to top button
-        const backToTop = document.getElementById('backToTop');
-        if (backToTop) {
-            window.addEventListener('scroll', function() {
-                if (window.pageYOffset > 300) {
-                    backToTop.classList.remove('opacity-0', 'invisible');
-                } else {
-                    backToTop.classList.add('opacity-0', 'invisible');
-                }
-            });
-            backToTop.addEventListener('click', function() {
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            });
-        }
         // Help modal toggle
         const helpButton = document.getElementById('helpButton');
         const helpModal = document.getElementById('quickHelpModal');

--- a/templates/base.html
+++ b/templates/base.html
@@ -93,6 +93,12 @@
     {% block content %}{% endblock %}
   </main>
 
+  <!-- Back to Top Button -->
+  <button id="backToTop" aria-label="Back to top"
+          class="back-to-top fixed bottom-8 right-8 p-4 rounded-full bg-primary-600 text-white hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 shadow-lg">
+    <i class="fas fa-arrow-up"></i>
+  </button>
+
   {% include 'partials/footer.html' %}
 
   <!-- Global JS -->

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -190,7 +190,7 @@
     <!-- Floating Action Buttons -->
     <div class="fixed right-6 bottom-6 space-y-3 z-40">
         <button aria-label="Back to top"
-                class="w-12 h-12 rounded-full flex items-center justify-center bg-gradient-to-r from-accent-purple to-primary-500 text-white shadow-lg transition-all duration-300 opacity-0 invisible hover:from-accent-purple/80 hover:to-primary-500/80 hover:shadow-glow focus:outline-none group"
+                class="back-to-top w-12 h-12 rounded-full flex items-center justify-center bg-gradient-to-r from-accent-purple to-primary-500 text-white shadow-lg transition-all duration-300 hover:from-accent-purple/80 hover:to-primary-500/80 hover:shadow-glow focus:outline-none group"
                 id="backToTop">
             <i class="fas fa-arrow-up group-hover:animate-bounce"></i>
         </button>
@@ -234,20 +234,6 @@
 <script src="{{ url_for('static', filename='js/catalog.js') }}" type="module"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
-        // Back to top button
-        const backToTop = document.getElementById('backToTop');
-        if (backToTop) {
-            window.addEventListener('scroll', function() {
-                if (window.pageYOffset > 300) {
-                    backToTop.classList.remove('opacity-0', 'invisible');
-                } else {
-                    backToTop.classList.add('opacity-0', 'invisible');
-                }
-            });
-            backToTop.addEventListener('click', function() {
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            });
-        }
         // Help modal toggle
         const helpButton = document.getElementById('helpButton');
         const helpModal = document.getElementById('quickHelpModal');

--- a/templates/index.html
+++ b/templates/index.html
@@ -103,7 +103,7 @@
 
 <!-- Back to Top Button -->
 <button aria-label="Back to top"
-        class="fixed bottom-8 right-8 p-4 rounded-full bg-primary-600 text-white hover:bg-primary-700 transition-all opacity-0 invisible focus:outline-none focus:ring-2 focus:ring-primary-500 shadow-lg back-to-top"
+        class="back-to-top fixed bottom-8 right-8 p-4 rounded-full bg-primary-600 text-white hover:bg-primary-700 transition-all focus:outline-none focus:ring-2 focus:ring-primary-500 shadow-lg"
         id="backToTop">
     <i aria-hidden="true" class="fas fa-arrow-up"></i>
 </button>
@@ -208,22 +208,6 @@ document.addEventListener('DOMContentLoaded', function() {
         window.requestAnimationFrame(step);
     }
 
-    // Initialize back to top button
-    const backToTop = document.getElementById('backToTop');
-    if (backToTop) {
-        window.addEventListener('scroll', () => {
-            const show = window.scrollY > 300;
-            backToTop.classList.toggle('opacity-0', !show);
-            backToTop.classList.toggle('invisible', !show);
-        });
-
-        backToTop.addEventListener('click', () => {
-            window.scrollTo({
-                top: 0,
-                behavior: 'smooth'
-            });
-        });
-    }
 
     // Initialize intersection observer for scroll animations
     const initScrollAnimations = () => {
@@ -331,11 +315,6 @@ document.addEventListener('DOMContentLoaded', function() {
         align-items: center;
         justify-content: center;
         z-index: 3;
-    }
-
-    /* Back to top button */
-    .back-to-top {
-        transition: all 0.3s ease, opacity 0.3s ease, visibility 0.3s ease;
     }
 
     /* Feature icons */


### PR DESCRIPTION
## Summary
- add floating "Back to Top" button to base layout
- apply same button on catalog, API test utility, and index pages
- remove per-page scripts for back-to-top handling
- style the button in main CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npx stylelint "src/**/*.css"` *(fails: 21 errors and network warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6866641b2d088333b570ad5250198790