### PR TITLE
Improve base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,9 @@
   <link rel="icon" href="{{ url_for('static', filename='img/favicon.svg') }}" type="image/svg+xml">
 
   <!-- Preload critical resources -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Plus+Jakarta+Sans:wght@600;700;800&family=Fira+Code:wght@400;500&display=swap" as="style">
   <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" as="style">
 
@@ -56,10 +59,10 @@
   </a>
 
   <!-- App loading indicator -->
-  <div id="app-loader" class="fixed inset-0 z-[9999] bg-dark-900 flex items-center justify-center transition-opacity duration-300">
+  <div id="app-loader" class="fixed inset-0 z-[9999] bg-dark-900 flex items-center justify-center transition-opacity duration-300" role="status" aria-live="polite">
     <div class="animate-pulse flex flex-col items-center">
       <div class="w-16 h-16 bg-gradient-to-r from-primary-500 to-accent-500 rounded-xl flex items-center justify-center mb-4">
-        <svg class="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <svg class="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
           <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="currentColor" stroke-width="2"/>
           <path d="M12 6V12L16 14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
         </svg>


### PR DESCRIPTION
## Summary
- preconnect to fonts and cdn resources for faster loading
- mark loader with ARIA attributes for improved accessibility
- add missing newline at end of template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68666f23db5c8333b70713a9d9e3ba3f