### PR TITLE
Enhance auth templates styling

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -3,22 +3,25 @@
 {% block title %}Login - Rules Central{% endblock %}
 
 {% block content %}
-<div class="max-w-md mx-auto mt-10 bg-white p-8 rounded-lg shadow-md">
+<div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg">
     <h2 class="text-2xl font-bold mb-6 text-center">Login</h2>
-    <form method="POST" action="{{ url_for('auth.login') }}">
+    <form id="loginForm" method="POST" action="{{ url_for('auth.login') }}" novalidate>
         <div class="mb-4">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="username">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="username">
                 Username
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="username" name="username" type="text" required>
         </div>
-        <div class="mb-6">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="password">
+        <div class="mb-6 relative">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="password">
                 Password
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="password" name="password" type="password" required>
+            <button type="button" id="togglePassword" class="absolute right-3 top-9 text-slate-400 hover:text-white">
+                <i class="fas fa-eye"></i>
+            </button>
         </div>
         <div class="flex items-center justify-between">
             <button class="w-full bg-primary-500 hover:bg-primary-600 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors"
@@ -27,10 +30,35 @@
             </button>
         </div>
         <div class="mt-4 text-center">
-            <a href="{{ url_for('auth.register') }}" class="text-primary-500 hover:text-primary-600 text-sm">
+            <a href="{{ url_for('auth.register') }}" class="text-primary-400 hover:text-primary-300 text-sm">
                 Don't have an account? Register
             </a>
         </div>
     </form>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggleBtn = document.getElementById('togglePassword');
+    const passwordInput = document.getElementById('password');
+    if (toggleBtn && passwordInput) {
+      toggleBtn.addEventListener('click', () => {
+        const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+        passwordInput.setAttribute('type', type);
+        toggleBtn.querySelector('i').classList.toggle('fa-eye');
+        toggleBtn.querySelector('i').classList.toggle('fa-eye-slash');
+      });
+    }
+
+    const form = document.getElementById('loginForm');
+    form.addEventListener('submit', (e) => {
+      if (!form.checkValidity()) {
+        e.preventDefault();
+      }
+    });
+  });
+</script>
 {% endblock %}

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -3,36 +3,42 @@
 {% block title %}Register - Rules Central{% endblock %}
 
 {% block content %}
-<div class="max-w-md mx-auto mt-10 bg-white p-8 rounded-lg shadow-md">
+<div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg">
     <h2 class="text-2xl font-bold mb-6 text-center">Create Account</h2>
-    <form method="POST" action="{{ url_for('auth.register') }}">
+    <form id="registerForm" method="POST" action="{{ url_for('auth.register') }}" novalidate>
         <div class="mb-4">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="username">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="username">
                 Username
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="username" name="username" type="text" required>
         </div>
         <div class="mb-4">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="email">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="email">
                 Email
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="email" name="email" type="email" required>
         </div>
-        <div class="mb-4">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="password">
+        <div class="mb-4 relative">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="password">
                 Password
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="password" name="password" type="password" required>
+            <button type="button" id="togglePassword" class="absolute right-3 top-9 text-slate-400 hover:text-white">
+                <i class="fas fa-eye"></i>
+            </button>
         </div>
-        <div class="mb-6">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="confirm_password">
+        <div class="mb-6 relative">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="confirm_password">
                 Confirm Password
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="confirm_password" name="confirm_password" type="password" required>
+            <button type="button" id="toggleConfirm" class="absolute right-3 top-9 text-slate-400 hover:text-white">
+                <i class="fas fa-eye"></i>
+            </button>
         </div>
         <div class="flex items-center justify-between">
             <button class="w-full bg-primary-500 hover:bg-primary-600 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors"
@@ -41,10 +47,39 @@
             </button>
         </div>
         <div class="mt-4 text-center">
-            <a href="{{ url_for('auth.login') }}" class="text-primary-500 hover:text-primary-600 text-sm">
+            <a href="{{ url_for('auth.login') }}" class="text-primary-400 hover:text-primary-300 text-sm">
                 Already have an account? Login
             </a>
         </div>
     </form>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    function toggleVisibility(btnId, inputId) {
+      const btn = document.getElementById(btnId);
+      const input = document.getElementById(inputId);
+      if (!btn || !input) return;
+      btn.addEventListener('click', () => {
+        const type = input.getAttribute('type') === 'password' ? 'text' : 'password';
+        input.setAttribute('type', type);
+        btn.querySelector('i').classList.toggle('fa-eye');
+        btn.querySelector('i').classList.toggle('fa-eye-slash');
+      });
+    }
+
+    toggleVisibility('togglePassword', 'password');
+    toggleVisibility('toggleConfirm', 'confirm_password');
+
+    const form = document.getElementById('registerForm');
+    form.addEventListener('submit', (e) => {
+      if (!form.checkValidity()) {
+        e.preventDefault();
+      }
+    });
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- overhaul login form layout with dark theme support
- update register page with matching style and password toggles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686672c5ba9c8333b67079c1e8e75e03