### PR TITLE
Enhance UX with global theme toggle and glass panels

### DIFF
--- a/templates/api_test_utility.html
+++ b/templates/api_test_utility.html
@@ -32,7 +32,7 @@
         <div class="absolute bottom-0 right-0 w-96 h-96 bg-primary-500 rounded-full filter blur-3xl opacity-10 animate-float animation-delay-2000"></div>
     </div>
     <div class="container mx-auto px-4 py-16 relative z-10">
-        <div class="glass-effect rounded-2xl shadow-2xl p-10 max-w-3xl mx-auto animate-fade-in">
+        <div class="panel panel--glass rounded-2xl shadow-2xl p-10 max-w-3xl mx-auto animate-fade-in">
             <form id="apiTestForm" class="space-y-8" method="POST" autocomplete="off">
                 <div class="flex flex-col md:flex-row gap-4 items-center">
                     <div class="w-full md:w-1/3">
@@ -74,7 +74,7 @@
             </form>
         </div>
 
-        <div class="glass-effect rounded-2xl mt-10 max-w-3xl mx-auto shadow-xl hidden animate-fade-in" id="apiResponsePanel">
+        <div class="panel panel--glass rounded-2xl mt-10 max-w-3xl mx-auto shadow-xl hidden animate-fade-in" id="apiResponsePanel">
             <div class="p-8">
                 <div class="flex items-center justify-between mb-6">
                     <h3 class="text-2xl font-bold text-white flex items-center">
@@ -102,7 +102,7 @@
             </div>
         </div>
 
-        <div class="fixed bottom-5 left-1/2 transform -translate-x-1/2 bg-dark-800 text-white px-6 py-3 rounded-xl shadow-lg hidden z-50 flex items-center glass-effect"
+        <div class="fixed bottom-5 left-1/2 transform -translate-x-1/2 bg-dark-800 text-white px-6 py-3 rounded-xl shadow-lg hidden z-50 flex items-center panel panel--glass"
              id="toast">
             <i class="fas fa-check-circle text-emerald-400 mr-3" id="toastIcon"></i>
             <div>
@@ -113,7 +113,7 @@
 
         <div class="fixed inset-0 bg-black/50 backdrop-blur-sm hidden flex items-center justify-center z-50"
              id="loadingOverlay">
-            <div class="flex flex-col items-center bg-dark-800 p-8 rounded-xl border border-slate-700/50 glass-effect">
+            <div class="flex flex-col items-center bg-dark-800 p-8 rounded-xl border border-slate-700/50 panel panel--glass">
                 <div class="loading-spinner rounded-full h-12 w-12 border-4 border-primary-500 border-t-transparent animate-spin"></div>
                 <p class="mt-4 text-white font-medium" id="loadingText">Sending request...</p>
                 <p class="text-sm text-slate-400 mt-1">Please wait for the API response</p>

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -3,22 +3,25 @@
 {% block title %}Login - Rules Central{% endblock %}
 
 {% block content %}
-<div class="max-w-md mx-auto mt-10 bg-white p-8 rounded-lg shadow-md">
+<div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg">
     <h2 class="text-2xl font-bold mb-6 text-center">Login</h2>
-    <form method="POST" action="{{ url_for('auth.login') }}">
+    <form id="loginForm" method="POST" action="{{ url_for('auth.login') }}" novalidate>
         <div class="mb-4">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="username">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="username">
                 Username
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="username" name="username" type="text" required>
         </div>
-        <div class="mb-6">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="password">
+        <div class="mb-6 relative">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="password">
                 Password
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="password" name="password" type="password" required>
+            <button type="button" id="togglePassword" class="absolute right-3 top-9 text-slate-400 hover:text-white">
+                <i class="fas fa-eye"></i>
+            </button>
         </div>
         <div class="flex items-center justify-between">
             <button class="w-full bg-primary-500 hover:bg-primary-600 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors"
@@ -27,10 +30,35 @@
             </button>
         </div>
         <div class="mt-4 text-center">
-            <a href="{{ url_for('auth.register') }}" class="text-primary-500 hover:text-primary-600 text-sm">
+            <a href="{{ url_for('auth.register') }}" class="text-primary-400 hover:text-primary-300 text-sm">
                 Don't have an account? Register
             </a>
         </div>
     </form>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggleBtn = document.getElementById('togglePassword');
+    const passwordInput = document.getElementById('password');
+    if (toggleBtn && passwordInput) {
+      toggleBtn.addEventListener('click', () => {
+        const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+        passwordInput.setAttribute('type', type);
+        toggleBtn.querySelector('i').classList.toggle('fa-eye');
+        toggleBtn.querySelector('i').classList.toggle('fa-eye-slash');
+      });
+    }
+
+    const form = document.getElementById('loginForm');
+    form.addEventListener('submit', (e) => {
+      if (!form.checkValidity()) {
+        e.preventDefault();
+      }
+    });
+  });
+</script>
 {% endblock %}

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -3,36 +3,42 @@
 {% block title %}Register - Rules Central{% endblock %}
 
 {% block content %}
-<div class="max-w-md mx-auto mt-10 bg-white p-8 rounded-lg shadow-md">
+<div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg">
     <h2 class="text-2xl font-bold mb-6 text-center">Create Account</h2>
-    <form method="POST" action="{{ url_for('auth.register') }}">
+    <form id="registerForm" method="POST" action="{{ url_for('auth.register') }}" novalidate>
         <div class="mb-4">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="username">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="username">
                 Username
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="username" name="username" type="text" required>
         </div>
         <div class="mb-4">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="email">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="email">
                 Email
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="email" name="email" type="email" required>
         </div>
-        <div class="mb-4">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="password">
+        <div class="mb-4 relative">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="password">
                 Password
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="password" name="password" type="password" required>
+            <button type="button" id="togglePassword" class="absolute right-3 top-9 text-slate-400 hover:text-white">
+                <i class="fas fa-eye"></i>
+            </button>
         </div>
-        <div class="mb-6">
-            <label class="block text-gray-700 text-sm font-bold mb-2" for="confirm_password">
+        <div class="mb-6 relative">
+            <label class="block text-sm font-semibold mb-2 text-gray-300" for="confirm_password">
                 Confirm Password
             </label>
-            <input class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            <input class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
                    id="confirm_password" name="confirm_password" type="password" required>
+            <button type="button" id="toggleConfirm" class="absolute right-3 top-9 text-slate-400 hover:text-white">
+                <i class="fas fa-eye"></i>
+            </button>
         </div>
         <div class="flex items-center justify-between">
             <button class="w-full bg-primary-500 hover:bg-primary-600 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors"
@@ -41,10 +47,39 @@
             </button>
         </div>
         <div class="mt-4 text-center">
-            <a href="{{ url_for('auth.login') }}" class="text-primary-500 hover:text-primary-600 text-sm">
+            <a href="{{ url_for('auth.login') }}" class="text-primary-400 hover:text-primary-300 text-sm">
                 Already have an account? Login
             </a>
         </div>
     </form>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    function toggleVisibility(btnId, inputId) {
+      const btn = document.getElementById(btnId);
+      const input = document.getElementById(inputId);
+      if (!btn || !input) return;
+      btn.addEventListener('click', () => {
+        const type = input.getAttribute('type') === 'password' ? 'text' : 'password';
+        input.setAttribute('type', type);
+        btn.querySelector('i').classList.toggle('fa-eye');
+        btn.querySelector('i').classList.toggle('fa-eye-slash');
+      });
+    }
+
+    toggleVisibility('togglePassword', 'password');
+    toggleVisibility('toggleConfirm', 'confirm_password');
+
+    const form = document.getElementById('registerForm');
+    form.addEventListener('submit', (e) => {
+      if (!form.checkValidity()) {
+        e.preventDefault();
+      }
+    });
+  });
+</script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -120,11 +120,18 @@
       // Theme management
       const html = document.documentElement;
       const btn = document.getElementById('theme-toggle');
+      const icon = btn?.querySelector('i');
+      const updateIcon = (theme) => {
+        if (!icon) return;
+        icon.classList.remove('fa-moon', 'fa-sun');
+        icon.classList.add(theme === 'dark' ? 'fa-sun' : 'fa-moon');
+      };
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
       const storedTheme = localStorage.getItem('theme') || (prefersDark ? 'dark' : 'light');
 
       html.setAttribute('data-theme', storedTheme);
       if (storedTheme === 'dark') html.classList.add('dark');
+      updateIcon(storedTheme);
 
       if (btn) {
         btn.addEventListener('click', () => {
@@ -132,6 +139,7 @@
           const theme = isDark ? 'dark' : 'light';
           html.setAttribute('data-theme', theme);
           localStorage.setItem('theme', theme);
+          updateIcon(theme);
 
           // Dispatch event for other components
           document.dispatchEvent(new CustomEvent('theme-change', { detail: { theme } }));

--- a/templates/config.html
+++ b/templates/config.html
@@ -105,7 +105,7 @@ Diagram Theme Manager – Rules Central
         <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
             <!-- Theme Selection Panel -->
             <div class="lg:col-span-4">
-                <div class="bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl shadow-lg transition-all duration-500 ease-out overflow-hidden">
+                <div class="panel panel--glass rounded-2xl shadow-lg transition-all duration-500 ease-out overflow-hidden">
                     <div class="p-6 border-b border-white/10 bg-gradient-to-r from-purple-900/30 to-blue-900/30">
                         <div class="flex items-center justify-between">
                             <h2 class="text-xl font-semibold text-white flex items-center">
@@ -210,7 +210,7 @@ Diagram Theme Manager – Rules Central
 
             <!-- Style Editor Panel -->
             <div class="lg:col-span-8">
-                <div class="bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl shadow-lg transition-all duration-500 ease-out overflow-hidden">
+                <div class="panel panel--glass rounded-2xl shadow-lg transition-all duration-500 ease-out overflow-hidden">
                     <div class="p-6 border-b border-white/10 bg-gradient-to-r from-purple-900/30 to-blue-900/30">
                         <div class="flex items-center justify-between">
                             <h2 class="text-xl font-semibold text-white flex items-center">
@@ -385,7 +385,7 @@ Diagram Theme Manager – Rules Central
                                     </button>
                                 </div>
                                 <div aria-live="polite"
-                                     class="bg-white/10 backdrop-blur-md border border-white/20 rounded-xl p-4 min-h-[300px] transition-all duration-500 ease-out" id="diagramContainer">
+                                     class="panel panel--glass p-4 min-h-[300px] transition-all duration-500 ease-out" id="diagramContainer">
                                     <div class="flex items-center justify-center h-full text-gray-500">
                                         <i class="fas fa-image mr-2"></i> Select a theme to see preview
                                     </div>
@@ -408,7 +408,7 @@ Diagram Theme Manager – Rules Central
     <!-- New Theme Modal -->
     <div aria-hidden="true"
          aria-modal="true" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 hidden modal-overlay backdrop-blur-sm" id="newThemeModal">
-        <div class="bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl shadow-2xl p-6 w-full max-w-md transition-all duration-500 ease-out" id="newThemeModalContent">
+        <div class="panel panel--glass shadow-2xl p-6 w-full max-w-md transition-all duration-500 ease-out" id="newThemeModalContent">
             <h3 class="text-xl font-semibold mb-4 text-white">Create New Theme</h3>
             <div class="space-y-4">
                 <div>
@@ -442,7 +442,7 @@ Diagram Theme Manager – Rules Central
     <!-- Confirm Delete Modal -->
     <div aria-hidden="true"
          aria-modal="true" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 hidden modal-overlay backdrop-blur-sm" id="confirmDeleteModal">
-        <div class="bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl shadow-2xl p-6 w-full max-w-md transition-all duration-500 ease-out" id="confirmDeleteModalContent">
+        <div class="panel panel--glass shadow-2xl p-6 w-full max-w-md transition-all duration-500 ease-out" id="confirmDeleteModalContent">
             <h3 class="text-xl font-semibold mb-4 text-white">Confirm Delete</h3>
             <p class="mb-4 text-gray-300">Are you sure you want to delete the theme "<span class="font-medium"
                                                                                            id="themeToDelete"></span>"?

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -110,6 +110,12 @@ Rules Extraction
                     </div>
                 </div>
 
+                <!-- Theme Toggle Button -->
+                <button id="theme-toggle" aria-label="Toggle theme"
+                        class="p-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white focus:outline-none transition-colors">
+                    <i class="fas fa-moon"></i>
+                </button>
+
                 <!-- Mobile Menu Button -->
                 <button class="md:hidden p-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white focus:outline-none"
                         id="mobile-menu-btn">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -13,7 +13,7 @@ Curate your profile for a personalized touch.
 
 {% block content %}
 <section role="region" aria-label="User Profile" class="container mx-auto px-4 py-12 max-w-6xl">
-    <div class="bg-white dark:bg-dark-800 rounded-xl shadow-lg overflow-hidden border border-gray-200 dark:border-dark-700">
+    <div class="panel panel--glass rounded-xl shadow-lg overflow-hidden border border-gray-200 dark:border-dark-700">
         <!-- Enhanced Profile Header -->
         <div class="relative">
             <div class="h-40 bg-gradient-to-r from-primary-600 to-accent-purple-600 rounded-t-xl"></div>
@@ -66,7 +66,7 @@ Curate your profile for a personalized touch.
 
             <!-- Stats Grid with Improved Visuals -->
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
-                <div class="bg-white dark:bg-dark-850 rounded-2xl p-6 border border-white/20 dark:border-white/20 shadow-md hover:shadow-lg transition-all duration-300 ease-out">
+                <div class="panel panel--glass rounded-2xl p-6 border border-white/20 dark:border-white/20 shadow-md hover:shadow-lg transition-all duration-300 ease-out">
                     <div class="flex items-center justify-between">
                         <div>
                             <div class="text-4xl font-bold text-primary-600 dark:text-primary-400">{{
@@ -83,7 +83,7 @@ Curate your profile for a personalized touch.
                     </div>
                 </div>
 
-                <div class="bg-white dark:bg-dark-850 rounded-2xl p-6 border border-white/20 dark:border-white/20 shadow-md hover:shadow-lg transition-all duration-300 ease-out">
+                <div class="panel panel--glass rounded-2xl p-6 border border-white/20 dark:border-white/20 shadow-md hover:shadow-lg transition-all duration-300 ease-out">
                     <div class="flex items-center justify-between">
                         <div>
                             <div class="text-4xl font-bold text-primary-600 dark:text-primary-400">{{
@@ -100,7 +100,7 @@ Curate your profile for a personalized touch.
                     </div>
                 </div>
 
-                <div class="bg-white dark:bg-dark-850 rounded-2xl p-6 border border-white/20 dark:border-white/20 shadow-md hover:shadow-lg transition-all duration-300 ease-out">
+                <div class="panel panel--glass rounded-2xl p-6 border border-white/20 dark:border-white/20 shadow-md hover:shadow-lg transition-all duration-300 ease-out">
                     <div class="flex items-center justify-between">
                         <div>
                             <div class="text-4xl font-bold text-primary-600 dark:text-primary-400">{{ stats.api_calls
@@ -131,7 +131,7 @@ Curate your profile for a personalized touch.
 
                 <div class="space-y-4">
                     {% for activity in stats.recent_activity %}
-                    <div class="flex items-start p-5 bg-white dark:bg-dark-700 rounded-xl border border-white/20 dark:border-white/20 hover:border-white/30 transition-all duration-300 ease-out group">
+                    <div class="flex items-start p-5 panel panel--glass rounded-xl border border-white/20 dark:border-white/20 hover:border-white/30 transition-all duration-300 ease-out group">
                         <div class="flex-shrink-0 mt-1">
                             <div class="h-12 w-12 rounded-full bg-primary-100 dark:bg-primary-900/20 flex items-center justify-center text-primary-600 dark:text-primary-400 group-hover:bg-primary-200 dark:group-hover:bg-primary-900/30 transition-colors">
                                 <i class="fas fa-{{ 'upload' if 'Upload' in activity.action else 'code-branch' if 'Extracted' in activity.action else 'plug' }} text-lg"></i>

--- a/templates/search.html
+++ b/templates/search.html
@@ -16,7 +16,7 @@ Search and discover diagrams across all catalogs in the Rules Central system
 <!-- Main Content -->
 <main class="container mx-auto px-4 sm:px-6 pb-16 flex-grow mt-6 relative z-10">
     <!-- Search Card -->
-    <div class="p-6 mb-8 rounded-xl bg-dark-850/80 border border-slate-700/30 shadow transition-all duration-500 hover:shadow-glow-lg">
+    <div class="panel panel--glass p-6 mb-8 rounded-xl shadow-lg transition-all duration-500 hover:shadow-glow-lg">
         <!-- Search Bar -->
         <div class="flex flex-col md:flex-row gap-4 mb-6">
             <div class="relative flex-1">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -26,7 +26,7 @@ Personalize your environment to suit your needs.
 
         <div class="p-6">
             <!-- Theme Selection -->
-            <div class="mb-8 bg-dark-850/80 rounded-lg p-6 shadow-md transition-shadow duration-200 hover:shadow-lg">
+            <div class="mb-8 panel panel--glass rounded-lg p-6 shadow-md transition-shadow duration-200 hover:shadow-lg">
                 <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-4 flex items-center">
                     <i class="fas fa-moon mr-2 text-primary-600 dark:text-primary-400"></i>Interface Theme
                 </h2>
@@ -44,7 +44,7 @@ Personalize your environment to suit your needs.
             </div>
 
             <!-- Timezone Display -->
-            <div class="mb-8 bg-dark-850/80 rounded-lg p-6 shadow-md transition-shadow duration-200 hover:shadow-lg">
+            <div class="mb-8 panel panel--glass rounded-lg p-6 shadow-md transition-shadow duration-200 hover:shadow-lg">
                 <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-4 flex items-center">
                     <i class="fas fa-clock mr-2 text-primary-600 dark:text-primary-400"></i>Timezone
                 </h2>
@@ -60,7 +60,7 @@ Personalize your environment to suit your needs.
             </div>
 
             <!-- Notification Preferences -->
-            <div class="mb-8 bg-dark-850/80 rounded-lg p-6 shadow-md transition-shadow duration-200 hover:shadow-lg">
+            <div class="mb-8 panel panel--glass rounded-lg p-6 shadow-md transition-shadow duration-200 hover:shadow-lg">
                 <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-4 flex items-center">
                     <i class="fas fa-bell mr-2 text-primary-600 dark:text-primary-400"></i>Notification Preferences
                 </h2>
@@ -106,7 +106,7 @@ Personalize your environment to suit your needs.
             <div class="border-t border-gray-200 dark:border-dark-700 my-8"></div>
 
             <!-- Security Section -->
-            <div class="mb-8 bg-dark-850/80 rounded-lg p-6 shadow-md transition-shadow duration-200 hover:shadow-lg">
+            <div class="mb-8 panel panel--glass rounded-lg p-6 shadow-md transition-shadow duration-200 hover:shadow-lg">
                 <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-4 flex items-center">
                     <i class="fas fa-shield-alt mr-2 text-primary-600 dark:text-primary-400"></i>Security
                 </h2>


### PR DESCRIPTION
## Summary
- add theme toggle button to header
- switch multiple pages to `panel--glass` styling for consistent look
- update base template to sync theme icon with mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686672c5ba9c8333b67079c1e8e75e03