### PR TITLE
Refactor utilities out of routes

### DIFF
--- a/all_routes.py
+++ b/all_routes.py
@@ -13,9 +13,13 @@ from flask import (
 from flask_login import current_user
 from werkzeug.utils import secure_filename
 from functions import (
-    generate_files, allowed_file,
-    ensure_directory_exists, load_and_sanitize_json,
+    generate_files,
+    allowed_file,
+    ensure_directory_exists,
+    load_and_sanitize_json,
     log_activity,
+    diagram_type_from_filename,
+    get_snippet,
 )
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -212,28 +216,6 @@ def search_diagrams():
         current_app.logger.error(f"Search error: {str(e)}", exc_info=True)
         return jsonify({'error': 'Server error during search'}), 500
 
-
-def diagram_type_from_filename(filename):
-    """Extract diagram type from filename pattern"""
-    if 'flowchart' in filename.lower():
-        return 'flowchart'
-    elif 'sequence' in filename.lower():
-        return 'sequence'
-    elif 'class' in filename.lower():
-        return 'class'
-    elif 'state' in filename.lower():
-        return 'state'
-    return None
-
-
-def get_snippet(content, query, snippet_length=100):
-    """Extract a snippet of text around the query match"""
-    index = content.find(query)
-    if index == -1:
-        return ''
-    start = max(0, index - snippet_length // 2)
-    end = min(len(content), index + len(query) + snippet_length // 2)
-    return content[start:end]
 
 
 @routes_bp.route('/api/hierarchy/<root_name>/<diagram_name>')

--- a/functions.py
+++ b/functions.py
@@ -533,3 +533,27 @@ def build_edge_map(edges):
                 right = right.split("|")[-1].strip()
             edge_map.setdefault(left, []).append(right)
     return edge_map
+
+
+def diagram_type_from_filename(filename: str) -> str | None:
+    """Return the diagram type inferred from its filename."""
+    fname = filename.lower()
+    if "flowchart" in fname:
+        return "flowchart"
+    if "sequence" in fname:
+        return "sequence"
+    if "class" in fname:
+        return "class"
+    if "state" in fname:
+        return "state"
+    return None
+
+
+def get_snippet(content: str, query: str, snippet_length: int = 100) -> str:
+    """Extract a short snippet of ``content`` around ``query``."""
+    index = content.find(query)
+    if index == -1:
+        return ""
+    start = max(0, index - snippet_length // 2)
+    end = min(len(content), index + len(query) + snippet_length // 2)
+    return content[start:end]

--- a/routes/upload.py
+++ b/routes/upload.py
@@ -1,22 +1,14 @@
 import os
 from flask import Blueprint, current_app, request, redirect, url_for, flash, render_template, jsonify
 from werkzeug.utils import secure_filename
+from functions import (
+    allowed_file,
+    load_and_sanitize_json,
+    ensure_directory_exists,
+    generate_files,
+)
 
 upload = Blueprint('upload', __name__)
-
-def allowed_file(filename):
-    return '.' in filename and filename.rsplit('.', 1)[1].lower() in {'json', 'mmd'}
-
-def load_and_sanitize_json(file_path):
-    # Placeholder: implement your JSON loading and validation here
-    return {}
-
-def ensure_directory_exists(path):
-    os.makedirs(path, exist_ok=True)
-
-def generate_files(json_data, output_dir):
-    # Placeholder: implement your file generation logic here
-    pass
 
 @upload.route('/upload', methods=['GET', 'POST'])
 def upload_file():


### PR DESCRIPTION
## Summary
- import common helpers directly from `functions`
- centralize filename utilities in `functions.py`
- clean up `upload` blueprint

## Testing
- `python -m compileall -q all_routes.py app.py functions.py routes/*.py services/*.py models.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_68667fef00d08333b985bfc85e62407b