### PR TITLE
Fix partial header and utility improvements

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -302,6 +302,7 @@ def get_node_click(rule, rule_to_page, current_page, root_name, edge_map):
                 break
     if target_page is not None:
         return f'click {guid} "/view_diagrams/{root_name}?page={target_page}" "View Page {target_page}"'
+    return ""
 
 def generate_mermaid_code(nodes, edges, layout="TD"):
     """Generate Mermaid code for the diagram."""
@@ -393,7 +394,7 @@ def log_activity(action, rule_id=None, user=None, details=None):
         data = {}
         if os.path.exists(activity_log_path):
             try:
-                with open(activity_log_path, 'r') as f:
+                with open(activity_log_path, 'r', encoding='utf-8') as f:
                     data = json.load(f)
             except (json.JSONDecodeError, FileNotFoundError):
                 data = {"rules": {}, "activity_log": []}
@@ -412,7 +413,7 @@ def log_activity(action, rule_id=None, user=None, details=None):
                 "last_modified": entry["timestamp"],
                 "modified_by": user or "system"
             }
-        with open(activity_log_path, 'w') as f:
+        with open(activity_log_path, 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=2)
     except Exception as e:
         logging.error(f"Failed to log activity: {str(e)}")
@@ -476,9 +477,10 @@ def highlight_matches(text, query):
         return text
     try:
         pattern = re.compile(re.escape(query), re.IGNORECASE)
-        return pattern.sub(lambda m: f'<strong>{m.group()}</strong>', text)
-    except Exception:
+    except re.error as exc:
+        logging.error("Invalid regex in highlight_matches: %s", exc)
         return text
+    return pattern.sub(lambda m: f'<strong>{m.group()}</strong>', text)
 def find_rule_by_guid(rules, guid):
     """Find a rule by its GUID."""
     for rule in rules:

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -1,14 +1,3 @@
-<!DOCTYPE html>
-<html class="h-full dark" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <title>Rules Central</title>
-    <!-- Load Font Awesome -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
-
-<body class="h-full">
-<!-- Enhanced Header Component -->
 <header class="bg-white dark:bg-dark-900/95 backdrop-blur-lg border-b border-gray-200 dark:border-slate-800/50 fixed w-full z-50 shadow-sm hover:shadow-md dark:shadow-xl dark:hover:shadow-2xl transition-all duration-300">
     <div class="container mx-auto px-4 sm:px-6">
         <div class="flex items-center justify-between h-16">
@@ -16,109 +5,62 @@
             <a aria-label="Rules Central Home" class="flex items-center group" href="{{ url_for('main.index') }}">
                 <div class="relative">
                     <div class="absolute -inset-2 bg-primary-500/10 rounded-full opacity-0 group-hover:opacity-100 blur-md transition-opacity duration-500"></div>
-                    <span class="text-xl font-bold text-gray-900 dark:text-white font-display tracking-tight relative z-10">
-Rules<span class="text-transparent bg-clip-text bg-gradient-to-r from-primary-500 to-primary-600">Central</span>
-<span class="absolute -bottom-1 left-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple w-0 group-hover:w-full transition-all duration-500"></span>
-</span>
+                    <span class="text-xl font-bold text-gray-900 dark:text-white font-display tracking-tight relative z-10">Rules<span class="text-transparent bg-clip-text bg-gradient-to-r from-primary-500 to-primary-600">Central</span>
+                        <span class="absolute -bottom-1 left-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple w-0 group-hover:w-full transition-all duration-500"></span>
+                    </span>
                 </div>
             </a>
 
             <!-- Desktop Navigation -->
             <nav class="hidden md:flex items-center space-x-1">
-                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group"
-                   href="{{ url_for('main.index') }}">
-<span class="relative z-10 flex items-center">
-<i class="fas fa-home mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>
-Home
-</span>
+                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group" href="{{ url_for('main.index') }}">
+                    <span class="relative z-10 flex items-center"><i class="fas fa-home mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>Home</span>
                     <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
                 </a>
-                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group"
-                   href="/upload">
-<span class="relative z-10 flex items-center">
-<i class="fas fa-upload mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>
-Upload
-</span>
+                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group" href="/upload">
+                    <span class="relative z-10 flex items-center"><i class="fas fa-upload mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>Upload</span>
                     <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
                 </a>
-                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group"
-                   href="/catalog">
-<span class="relative z-10 flex items-center">
-<i class="fas fa-folder mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>
-Catalog
-</span>
+                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group" href="/catalog">
+                    <span class="relative z-10 flex items-center"><i class="fas fa-folder mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>Catalog</span>
                     <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
                 </a>
-                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group"
-                   href="/search">
-<span class="relative z-10 flex items-center">
-<i class="fas fa-search mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>
-Search
-</span>
+                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group" href="/search">
+                    <span class="relative z-10 flex items-center"><i class="fas fa-search mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>Search</span>
                     <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
                 </a>
-                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group"
-                   href="/config">
-<span class="relative z-10 flex items-center">
-<i class="fas fa-cog mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>
-Configuration
-</span>
+                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group" href="/config">
+                    <span class="relative z-10 flex items-center"><i class="fas fa-cog mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>Configuration</span>
                     <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
                 </a>
-                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group"
-                   href="/api_test_utility">
-<span class="relative z-10 flex items-center">
-<i class="fas fa-plug mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>
-API Test
-</span>
+                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group" href="/api_test_utility">
+                    <span class="relative z-10 flex items-center"><i class="fas fa-plug mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>API Test</span>
                     <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
                 </a>
-                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group"
-                   href="/rules_extraction_utility">
-<span class="relative z-10 flex items-center">
-<i class="fas fa-code-branch mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>
-Rules Extraction
-</span>
+                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group" href="/rules_extraction_utility">
+                    <span class="relative z-10 flex items-center"><i class="fas fa-code-branch mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>Rules Extraction</span>
                     <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
                 </a>
             </nav>
 
             <!-- Right Side Controls -->
             <div class="flex items-center space-x-4">
-
-                <!-- User Menu -->
                 <div class="relative" id="user-menu-container">
-                    <button aria-label="User Menu"
-                            class="w-10 h-10 rounded-full bg-gradient-to-br from-primary-500 to-accent-purple text-white flex items-center justify-center shadow-md hover:shadow-glow-lg transition-all duration-300 transform hover:scale-105 group"
-                            id="user-menu-button">
+                    <button aria-label="User Menu" class="w-10 h-10 rounded-full bg-gradient-to-br from-primary-500 to-accent-purple text-white flex items-center justify-center shadow-md hover:shadow-glow-lg transition-all duration-300 transform hover:scale-105 group" id="user-menu-button">
                         <div class="absolute inset-0 rounded-full bg-white/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                         <i class="fas fa-user transition-transform duration-300 group-hover:scale-110 relative z-10"></i>
                     </button>
-
-                    <!-- User Dropdown Menu -->
-                    <div class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-dark-800 rounded-md shadow-lg py-1 border border-gray-200 dark:border-slate-700 z-50 animate-fadeIn"
-                         id="user-dropdown">
-                        <a class="block px-4 py-2 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-dark-700"
-                           href="/profile">Your
-                            Profile</a>
-                        <a class="block px-4 py-2 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-dark-700"
-                           href="/settings">Settings</a>
+                    <div class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-dark-800 rounded-md shadow-lg py-1 border border-gray-200 dark:border-slate-700 z-50 animate-fadeIn" id="user-dropdown">
+                        <a class="block px-4 py-2 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-dark-700" href="/profile">Your Profile</a>
+                        <a class="block px-4 py-2 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-dark-700" href="/settings">Settings</a>
                         <div class="border-t border-gray-200 dark:border-slate-700 my-1"></div>
-                        <a class="block px-4 py-2 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-dark-700"
-                           href="/logout">Sign
-                            out</a>
+                        <a class="block px-4 py-2 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-dark-700" href="/logout">Sign out</a>
                     </div>
                 </div>
-
-                <!-- Theme Toggle Button -->
-                <button id="theme-toggle" aria-label="Toggle theme"
-                        class="p-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white focus:outline-none transition-colors">
+                <button id="theme-toggle" aria-label="Toggle theme" class="p-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white focus:outline-none transition-colors">
                     <i class="fas fa-moon"></i>
                 </button>
-
-                <!-- Mobile Menu Button -->
-                <button class="md:hidden p-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white focus:outline-none"
-                        id="mobile-menu-btn">
+                <button class="md:hidden p-2 rounded-md text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white focus:outline-none" id="mobile-menu-btn">
                     <span class="sr-only">Open menu</span>
                     <i class="fas fa-bars" id="menu-icon"></i>
                     <i class="fas fa-times opacity-0" id="close-icon"></i>
@@ -127,48 +69,39 @@ Rules Extraction
         </div>
     </div>
 
-    <!-- Mobile Navigation Menu -->
-    <div class="md:hidden hidden bg-white dark:bg-dark-900/95 backdrop-blur-lg border-t border-gray-200 dark:border-slate-800/50 shadow-lg transition-all duration-300 transform origin-top scale-y-0"
-         id="mobile-menu">
+    <div class="md:hidden hidden bg-white dark:bg-dark-900/95 backdrop-blur-lg border-t border-gray-200 dark:border-slate-800/50 shadow-lg transition-all duration-300 transform origin-top scale-y-0" id="mobile-menu">
         <div class="px-6 py-4 space-y-1">
-            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group"
-               href="{{ url_for('main.index') }}">
+            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="{{ url_for('main.index') }}">
                 <i class="fas fa-home mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
                 <span>Home</span>
                 <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
             </a>
-            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group"
-               href="/upload">
+            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="/upload">
                 <i class="fas fa-upload mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
                 <span>Upload</span>
                 <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
             </a>
-            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group"
-               href="/catalog">
+            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="/catalog">
                 <i class="fas fa-folder mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
                 <span>Catalog</span>
                 <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
             </a>
-            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group"
-               href="/search">
+            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="/search">
                 <i class="fas fa-search mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
                 <span>Search</span>
                 <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
             </a>
-            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group"
-               href="/config">
+            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="/config">
                 <i class="fas fa-cog mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
                 <span>Configuration</span>
                 <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
             </a>
-            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group"
-               href="/api_test_utility">
+            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="/api_test_utility">
                 <i class="fas fa-plug mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
                 <span>API Test</span>
                 <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
             </a>
-            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group"
-               href="/rules_extraction_utility">
+            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="/rules_extraction_utility">
                 <i class="fas fa-code-branch mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
                 <span>Rules Extraction</span>
                 <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
@@ -176,72 +109,54 @@ Rules Extraction
         </div>
     </div>
 </header>
-
-
 <script>
     document.addEventListener('DOMContentLoaded', () => {
-
-    // User Menu Functionality
-    const userMenuButton = document.getElementById('user-menu-button');
-    const userDropdown = document.getElementById('user-dropdown');
-
-    userMenuButton.addEventListener('click', (e) => {
-    e.stopPropagation();
-    userDropdown.classList.toggle('hidden');
-    });
-
-    // Close user dropdown when clicking outside
-    document.addEventListener('click', (e) => {
-    if (!userDropdown.contains(e.target) && e.target !== userMenuButton) {
-    userDropdown.classList.add('hidden');
-    }
-    });
-
-    // Mobile Menu Functionality
-    const mobileMenuBtn = document.getElementById('mobile-menu-btn');
-    const mobileMenu = document.getElementById('mobile-menu');
-    const menuIcon = document.getElementById('menu-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    mobileMenuBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    mobileMenu.classList.toggle('hidden');
-    mobileMenu.classList.toggle('scale-y-0');
-    mobileMenu.classList.toggle('scale-y-100');
-
-    if (mobileMenu.classList.contains('hidden')) {
-    menuIcon.classList.remove('opacity-0');
-    closeIcon.classList.add('opacity-0');
-    } else {
-    menuIcon.classList.add('opacity-0');
-    closeIcon.classList.remove('opacity-0');
-    }
-    });
-
-    // Close mobile menu when clicking outside
-    document.addEventListener('click', (e) => {
-    if (!mobileMenu.contains(e.target) && e.target !== mobileMenuBtn) {
-    mobileMenu.classList.add('hidden');
-    mobileMenu.classList.remove('scale-y-100');
-    mobileMenu.classList.add('scale-y-0');
-    menuIcon.classList.remove('opacity-0');
-    closeIcon.classList.add('opacity-0');
-    }
-    });
-
-    // Highlight current page in navigation
-    const currentPath = window.location.pathname;
-    const navLinks = document.querySelectorAll('nav a, #mobile-menu a');
-    navLinks.forEach(link => {
-    if (link.getAttribute('href') === currentPath) {
-    link.classList.add('text-gray-900', 'dark:text-white');
-    const underline = link.querySelector('span:last-child');
-    if (underline) {
-    underline.classList.add('w-4/5', 'left-[10%]');
-    }
-    }
-    });
+        const userMenuButton = document.getElementById('user-menu-button');
+        const userDropdown = document.getElementById('user-dropdown');
+        userMenuButton.addEventListener('click', e => {
+            e.stopPropagation();
+            userDropdown.classList.toggle('hidden');
+        });
+        document.addEventListener('click', e => {
+            if (!userDropdown.contains(e.target) && e.target !== userMenuButton) {
+                userDropdown.classList.add('hidden');
+            }
+        });
+        const mobileMenuBtn = document.getElementById('mobile-menu-btn');
+        const mobileMenu = document.getElementById('mobile-menu');
+        const menuIcon = document.getElementById('menu-icon');
+        const closeIcon = document.getElementById('close-icon');
+        mobileMenuBtn.addEventListener('click', e => {
+            e.stopPropagation();
+            mobileMenu.classList.toggle('hidden');
+            mobileMenu.classList.toggle('scale-y-0');
+            mobileMenu.classList.toggle('scale-y-100');
+            if (mobileMenu.classList.contains('hidden')) {
+                menuIcon.classList.remove('opacity-0');
+                closeIcon.classList.add('opacity-0');
+            } else {
+                menuIcon.classList.add('opacity-0');
+                closeIcon.classList.remove('opacity-0');
+            }
+        });
+        document.addEventListener('click', e => {
+            if (!mobileMenu.contains(e.target) && e.target !== mobileMenuBtn) {
+                mobileMenu.classList.add('hidden');
+                mobileMenu.classList.remove('scale-y-100');
+                mobileMenu.classList.add('scale-y-0');
+                menuIcon.classList.remove('opacity-0');
+                closeIcon.classList.add('opacity-0');
+            }
+        });
+        const currentPath = window.location.pathname;
+        document.querySelectorAll('nav a, #mobile-menu a').forEach(link => {
+            if (link.getAttribute('href') === currentPath) {
+                link.classList.add('text-gray-900', 'dark:text-white');
+                const underline = link.querySelector('span:last-child');
+                if (underline) {
+                    underline.classList.add('w-4/5', 'left-[10%]');
+                }
+            }
+        });
     });
 </script>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- return empty string when nodes have no clickable link
- log regex errors and return unchanged text in `highlight_matches`
- rework header partial to remove stray `<html>` and `<body>` wrappers

## Testing
- `python -m py_compile $(find . -name '*.py' -not -path './node_modules/*')`
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_6866a59cc96c833390987cd9359ae3cb