### PR TITLE
Add body attribute block

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,7 @@
   {% block head %}{% endblock %}
 </head>
 
-<body class="min-h-screen flex flex-col bg-gradient-to-br from-dark-950 to-dark-900 text-slate-300 font-sans antialiased leading-relaxed tracking-normal">
+<body class="min-h-screen flex flex-col bg-gradient-to-br from-dark-950 to-dark-900 text-slate-300 font-sans antialiased leading-relaxed tracking-normal" {% block body_attrs %}{% endblock %}>
   <!-- Skip link for accessibility -->
   <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:bg-primary-600 focus:text-white focus:px-4 focus:py-2 focus:rounded-lg focus:ring-2 focus:ring-offset-2 focus:ring-offset-dark-900 focus:ring-primary-500">
     Skip to content

--- a/templates/diagram_viewer.html
+++ b/templates/diagram_viewer.html
@@ -2,6 +2,8 @@
 
 {% block title %}{{ root_name }} - {{ diagram_name }} | Visualizer Pro{% endblock %}
 
+{% block body_attrs %}data-root-name="{{ root_name }}" data-diagram-name="{{ diagram_name }}"{% endblock %}
+
 {% block head %}
 
 {% endblock %}

--- a/templates/hierarchy_viewer.html
+++ b/templates/hierarchy_viewer.html
@@ -2,6 +2,8 @@
 
 {% block title %}{{ diagram_name.replace('.json', '') }} - Hierarchy Viewer | Rules Central{% endblock %}
 
+{% block body_attrs %}data-root-name="{{ root_name }}" data-diagram-name="{{ diagram_name }}"{% endblock %}
+
 {% block head %}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0/dist/themes/dark.css">
 {% endblock %}
@@ -9,17 +11,12 @@
 {% block hero %}{% endblock %}
 
 {% block content %}
-<div class="container mx-auto px-4 sm:px-6 py-6 flex-grow"
-     data-root-name="{{ root_name }}" data-diagram-name="{{ diagram_name }}">
+<div class="container mx-auto px-4 sm:px-6 py-6 flex-grow">
   {% include 'partials/hierarchy_viewer_body.html' %}
 </div>
 {% endblock %}
 
 {% block scripts %}
-  <script>
-    document.body.dataset.rootName = "{{ root_name }}";
-    document.body.dataset.diagramName = "{{ diagram_name }}";
-  </script>
   <script defer src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0/dist/shoelace.js"></script>
   <script type="module" src="{{ url_for('static', filename='js/hierarchy_viewer.js') }}"></script>


### PR DESCRIPTION
## Summary
- enable templates to set attributes directly on `<body>`
- remove inline dataset script from hierarchy viewer and use new body attributes
- provide root and diagram names as body attributes in diagram viewer

## Testing
- `npm run lint:css`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6866b1b33d3883338a618f7be54347b0