### PR TITLE
Align hero usage across templates

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% block title %}Page Not Found{% endblock %}
+{% block hero_title %}404 - Page Not Found{% endblock %}
+{% block hero_subtitle %}The page you're looking for doesn't exist or has been moved.{% endblock %}
 
 {% block content %}
 <div class="min-h-screen flex items-center justify-center bg-dark-900">

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% block title %}Server Error{% endblock %}
+{% block hero_title %}500 - Server Error{% endblock %}
+{% block hero_subtitle %}Something went wrong on our end. We're working to fix it.{% endblock %}
 
 {% block content %}
 <div class="min-h-screen flex items-center justify-center bg-dark-900">

--- a/templates/api_test_utility.html
+++ b/templates/api_test_utility.html
@@ -2,28 +2,8 @@
 
 {% block title %}API Test Utility – Rules Central{% endblock %}
 
-{% block hero %}
-<section class="hero-section relative overflow-hidden bg-gradient-to-br from-dark-900 to-dark-800 py-24">
-    <div class="particles absolute inset-0 overflow-hidden pointer-events-none">
-        <div class="particle"></div>
-        <div class="particle"></div>
-        <div class="particle"></div>
-    </div>
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold mb-6 tracking-tighter gradient-text bg-gradient-to-r from-primary-400 via-accent-purple to-primary-500">
-            API Test Utility
-        </h1>
-        <div class="max-w-3xl mx-auto">
-            <p class="text-xl md:text-2xl text-slate-300 leading-relaxed">
-                <span class="typing-effect">Interactively test and debug your API endpoints</span>
-            </p>
-        </div>
-        <div class="mt-12 animate-bounce">
-            <i class="fas fa-chevron-down text-2xl text-white opacity-70"></i>
-        </div>
-    </div>
-</section>
-{% endblock %}
+{% block hero_title %}API Test Utility{% endblock %}
+{% block hero_subtitle %}Interactively test and debug your API endpoints{% endblock %}
 
 {% block content %}
 <div class="relative min-h-screen bg-gradient-to-br from-dark-950 to-dark-900 text-white overflow-hidden">

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -2,28 +2,8 @@
 
 {% block title %}Catalog Viewer – Rules Central{% endblock %}
 
-{% block hero %}
-<section class="hero-section relative overflow-hidden bg-gradient-to-br from-dark-900 to-dark-800 py-24">
-    <div class="particles absolute inset-0 overflow-hidden pointer-events-none">
-        <div class="particle"></div>
-        <div class="particle"></div>
-        <div class="particle"></div>
-    </div>
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold mb-6 tracking-tighter gradient-text bg-gradient-to-r from-primary-400 via-accent-purple to-primary-500">
-            Catalog Viewer
-        </h1>
-        <div class="max-w-3xl mx-auto">
-            <p class="text-xl md:text-2xl text-slate-300 leading-relaxed">
-                <span class="typing-effect">Explore and search diagrams in the Rules Central catalog</span>
-            </p>
-        </div>
-        <div class="mt-12 animate-bounce">
-            <i class="fas fa-chevron-down text-2xl text-white opacity-70"></i>
-        </div>
-    </div>
-</section>
-{% endblock %}
+{% block hero_title %}Catalog Viewer{% endblock %}
+{% block hero_subtitle %}Explore and search diagrams in the Rules Central catalog{% endblock %}
 
 {% block content %}
 <div class="relative min-h-screen bg-gradient-to-br from-dark-950 to-dark-900 text-white overflow-hidden">

--- a/templates/config.html
+++ b/templates/config.html
@@ -4,36 +4,8 @@
 Diagram Theme Manager – Rules Central
 {% endblock %}
 
-{% block hero %}
-<!-- Hero Section with Floating Particles -->
-<section role="region" aria-label="Diagram Theme Hero" class="hero-section relative overflow-hidden bg-gradient-to-br from-gray-900 to-gray-800 py-16">
-    <!-- Animated particles background -->
-    <div class="particles absolute inset-0 overflow-hidden pointer-events-none">
-        <div class="particle"></div>
-        <div class="particle"></div>
-        <div class="particle"></div>
-    </div>
-
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <!-- Main Title with Animated Gradient -->
-        <h1 class="text-5xl md:text-6xl lg:text-7xl font-bold mb-6 tracking-tighter">
-            <span class="gradient-text bg-gradient-to-r from-purple-400 via-pink-500 to-blue-400">Diagram Theme</span>
-        </h1>
-
-        <!-- Subtitle with animated typing effect -->
-        <div class="max-w-3xl mx-auto">
-            <p class="text-xl md:text-2xl text-gray-300 leading-relaxed">
-                <span class="typing-effect">Customize Mermaid diagram styles and themes with real-time preview</span>
-            </p>
-        </div>
-
-        <!-- Animated scroll indicator -->
-        <div class="mt-12 animate-bounce">
-            <i class="fas fa-chevron-down text-2xl text-white opacity-70" aria-hidden="true"></i>
-        </div>
-    </div>
-</section>
-{% endblock %}
+{% block hero_title %}Diagram Theme{% endblock %}
+{% block hero_subtitle %}Customize Mermaid diagram styles and themes with real-time preview{% endblock %}
 
 {% block content %}
 <section role="region" aria-label="Theme Manager" class="container mx-auto px-4 sm:px-6 py-8 bg-dark-900/80 rounded-2xl shadow-lg">

--- a/templates/diagram_viewer.html
+++ b/templates/diagram_viewer.html
@@ -8,6 +8,8 @@
 
 {% endblock %}
 
+{% block hero %}{% endblock %}
+
 {% block content %}
 <div class="container mx-auto px-4 sm:px-6 pb-12 flex-grow">
     <!-- Hero Section -->

--- a/templates/full_help.html
+++ b/templates/full_help.html
@@ -6,20 +6,8 @@
 
 {% endblock %}
 
-{% block hero %}
-<!-- Hero Section -->
-<section class="doc-hero">
-    <div class="doc-hero-content">
-        <h1>Rules Central Documentation</h1>
-        <p>Complete guide to all features and functionality - Version {{ config.VERSION }}</p>
-    </div>
-    <div class="doc-hero-bg">
-        <div class="circle circle-1"></div>
-        <div class="circle circle-2"></div>
-        <div class="circle circle-3"></div>
-    </div>
-</section>
-{% endblock %}
+{% block hero_title %}Rules Central Documentation{% endblock %}
+{% block hero_subtitle %}Complete guide to all features and functionality - Version {{ config.VERSION }}{% endblock %}
 
 {% block content %}
 <div class="content-wrapper container mx-auto px-4 sm:px-6">

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -2,36 +2,8 @@
 
 {% block title %}Upload JSON Diagrams – Rules Central{% endblock %}
 
-{% block hero %}
-<!-- Hero Section with Floating Particles -->
-<section class="hero-section relative overflow-hidden bg-gradient-to-br from-gray-900 to-gray-800 py-24">
-<!-- Animated particles background -->
-<div class="particles absolute inset-0 overflow-hidden pointer-events-none">
-<div class="particle"></div>
-<div class="particle"></div>
-<div class="particle"></div>
-</div>
-
-<div class="container mx-auto px-4 text-center relative z-10">
-<!-- Main Title with Animated Gradient -->
-<h1 class="text-5xl md:text-6xl lg:text-7xl font-bold mb-6 tracking-tighter">
-<span class="gradient-text bg-gradient-to-r from-purple-400 via-pink-500 to-blue-400">Upload Diagrams</span>
-</h1>
-
-<!-- Subtitle with animated typing effect -->
-<div class="max-w-3xl mx-auto">
-<p class="text-xl md:text-2xl text-gray-300 leading-relaxed">
-<span class="typing-effect">Upload and process your JSON diagram files</span>
-</p>
-</div>
-
-<!-- Animated scroll indicator -->
-<div class="mt-12 animate-bounce">
-<i class="fas fa-chevron-down text-2xl text-white opacity-70"></i>
-</div>
-</div>
-</section>
-{% endblock %}
+{% block hero_title %}Upload Diagrams{% endblock %}
+{% block hero_subtitle %}Upload and process your JSON diagram files{% endblock %}
 
 {% block content %}
 <div class="relative min-h-screen bg-gray-900 text-white overflow-hidden">


### PR DESCRIPTION
## Summary
- update templates to use `hero_title` and `hero_subtitle`
- remove duplicated hero markup
- disable base hero on diagram viewer to avoid duplicate hero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866b600ec788333bce69dc9507c2869