### PR TITLE
Improve template polish

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1862,3 +1862,20 @@ body {
   visibility: visible;
   transform: translateY(0);
 }
+
+/* Polished cards for auth and error pages */
+.auth-card,
+.error-card {
+  background: rgba(17, 24, 39, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
+  padding: 2rem;
+}
+
+.error-icon {
+  color: var(--primary-400);
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}

--- a/templates/404.html
+++ b/templates/404.html
@@ -6,7 +6,10 @@
 
 {% block content %}
 <div class="min-h-screen flex items-center justify-center bg-dark-900">
-    <div class="text-center p-8 bg-dark-800 rounded-lg shadow-xl max-w-md mx-4">
+    <div class="error-card text-center max-w-md mx-4">
+        <div class="error-icon">
+            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+        </div>
         <h1 class="text-4xl font-bold text-white mb-4">404 - Page Not Found</h1>
         <p class="text-xl text-gray-300 mb-8">The page you're looking for doesn't exist or has been moved.</p>
         <a href="{{ url_for('main.index') }}"

--- a/templates/500.html
+++ b/templates/500.html
@@ -6,7 +6,10 @@
 
 {% block content %}
 <div class="min-h-screen flex items-center justify-center bg-dark-900">
-    <div class="text-center p-8 bg-dark-800 rounded-lg shadow-xl max-w-md mx-4">
+    <div class="error-card text-center max-w-md mx-4">
+        <div class="error-icon">
+            <i class="fas fa-server" aria-hidden="true"></i>
+        </div>
         <h1 class="text-4xl font-bold text-white mb-4">500 - Server Error</h1>
         <p class="text-xl text-gray-300 mb-6">Something went wrong on our end. We're working to fix it.</p>
         <p class="text-lg text-gray-400 mb-8">Please try again later or contact support if the problem persists.</p>

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -3,7 +3,10 @@
 {% block title %}Login - Rules Central{% endblock %}
 
 {% block content %}
-<div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg">
+<div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg auth-card">
+    <div class="text-center mb-4 text-primary-400">
+        <i class="fas fa-sign-in-alt text-4xl"></i>
+    </div>
     <h2 class="text-2xl font-bold mb-6 text-center">Login</h2>
     <form id="loginForm" method="POST" action="{{ url_for('auth.login') }}" novalidate>
         <div class="mb-4">

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -3,7 +3,10 @@
 {% block title %}Register - Rules Central{% endblock %}
 
 {% block content %}
-<div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg">
+<div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg auth-card">
+    <div class="text-center mb-4 text-primary-400">
+        <i class="fas fa-user-plus text-4xl"></i>
+    </div>
     <h2 class="text-2xl font-bold mb-6 text-center">Create Account</h2>
     <form id="registerForm" method="POST" action="{{ url_for('auth.register') }}" novalidate>
         <div class="mb-4">


### PR DESCRIPTION
## Summary
- style auth and error pages with reusable polished card styles
- add icons to 404, 500, login, and register pages

## Testing
- `npm run lint:css`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866be40234c8333bc2aeaef7dfa5e7a