### PR TITLE
Refactor Back to Top button

### DIFF
--- a/templates/api_test_utility.html
+++ b/templates/api_test_utility.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set show_back_to_top = false %}
 
 {% block title %}API Test Utility – Rules Central{% endblock %}
 
@@ -103,11 +104,7 @@
 
     <!-- Floating Action Buttons -->
     <div class="fixed right-6 bottom-6 space-y-3 z-40">
-        <button aria-label="Back to top"
-                class="back-to-top w-12 h-12 rounded-full flex items-center justify-center bg-gradient-to-r from-accent-purple to-primary-500 text-white shadow-lg transition-all duration-300 hover:from-accent-purple/80 hover:to-primary-500/80 hover:shadow-glow focus:outline-none group"
-                id="backToTop">
-            <i class="fas fa-arrow-up group-hover:animate-bounce"></i>
-        </button>
+        {% include 'partials/back_to_top.html' %}
         <button aria-label="Help"
                 class="w-12 h-12 bg-dark-800/60 text-slate-300 rounded-full shadow-lg hover:bg-dark-700/60 transition-colors flex items-center justify-center group"
                 id="helpButton">

--- a/templates/base.html
+++ b/templates/base.html
@@ -96,11 +96,12 @@
     {% block content %}{% endblock %}
   </main>
 
-  <!-- Back to Top Button -->
-  <button id="backToTop" aria-label="Back to top"
-          class="back-to-top fixed bottom-8 right-8 p-4 rounded-full bg-primary-600 text-white hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 shadow-lg">
-    <i class="fas fa-arrow-up"></i>
-  </button>
+  {% if show_back_to_top is not defined or show_back_to_top %}
+    <!-- Back to Top Button -->
+    <div class="fixed bottom-8 right-8">
+      {% include 'partials/back_to_top.html' %}
+    </div>
+  {% endif %}
 
   {% include 'partials/footer.html' %}
 

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set show_back_to_top = false %}
 
 {% block title %}Catalog Viewer – Rules Central{% endblock %}
 
@@ -169,11 +170,7 @@
 
     <!-- Floating Action Buttons -->
     <div class="fixed right-6 bottom-6 space-y-3 z-40">
-        <button aria-label="Back to top"
-                class="back-to-top w-12 h-12 rounded-full flex items-center justify-center bg-gradient-to-r from-accent-purple to-primary-500 text-white shadow-lg transition-all duration-300 hover:from-accent-purple/80 hover:to-primary-500/80 hover:shadow-glow focus:outline-none group"
-                id="backToTop">
-            <i class="fas fa-arrow-up group-hover:animate-bounce"></i>
-        </button>
+        {% include 'partials/back_to_top.html' %}
         <button aria-label="Help"
                 class="w-12 h-12 bg-dark-800/60 text-slate-300 rounded-full shadow-lg hover:bg-dark-700/60 transition-colors flex items-center justify-center group"
                 id="helpButton">

--- a/templates/index.html
+++ b/templates/index.html
@@ -101,12 +101,6 @@
     </div>
 </section>
 
-<!-- Back to Top Button -->
-<button aria-label="Back to top"
-        class="back-to-top fixed bottom-8 right-8 p-4 rounded-full bg-primary-600 text-white hover:bg-primary-700 transition-all focus:outline-none focus:ring-2 focus:ring-primary-500 shadow-lg"
-        id="backToTop">
-    <i aria-hidden="true" class="fas fa-arrow-up"></i>
-</button>
 
 <!-- Loading Overlay (for initial load) -->
 <div class="fixed inset-0 bg-dark-900/80 flex items-center justify-center z-50 transition-opacity duration-300 opacity-0 pointer-events-none" id="globalLoader">

--- a/templates/partials/back_to_top.html
+++ b/templates/partials/back_to_top.html
@@ -1,0 +1,4 @@
+<button id="backToTop" aria-label="Back to top"
+        class="back-to-top w-12 h-12 rounded-full flex items-center justify-center bg-gradient-to-r from-accent-purple to-primary-500 text-white shadow-lg transition-all duration-300 hover:from-accent-purple/80 hover:to-primary-500/80 hover:shadow-glow focus:outline-none">
+    <i class="fas fa-arrow-up"></i>
+</button>


### PR DESCRIPTION
## Summary
- extract back-to-top button into a reusable partial
- include new partial from `base.html`
- remove duplicate markup from `index.html`
- use the partial in API Test Utility and Catalog pages
- allow pages to disable the base button via `show_back_to_top`

## Testing
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_6866e54dfa14833383d4a7f27e2989db