### PR TITLE
Fix icon paths and config initialization

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,3 +38,4 @@ class Config:
             with open(cls.ACTIVITY_LOG, 'w') as f:
                 json.dump(initial_data, f, indent=2)
             cls.ACTIVITY_LOG.chmod(0o644)
+        return cls.ACTIVITY_LOG

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -7,12 +7,12 @@
   "theme_color": "#0ea5e9",
   "icons": [
     {
-      "src": "/static/icons/icon-192.png",
+      "src": "/static/images/RulesCentralLogo.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "/static/icons/icon-512.png",
+      "src": "/static/images/RulesCentralLogo.png",
       "type": "image/png",
       "sizes": "512x512"
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#0e1524">
 
   <title>{% block title %}Rules Central{% endblock %}</title>
-  <link rel="icon" href="{{ url_for('static', filename='img/favicon.svg') }}" type="image/svg+xml">
+  <link rel="icon" href="{{ url_for('static', filename='images/favicon.ico') }}" type="image/x-icon">
 
   <!-- Preload critical resources -->
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- correct favicon path in base template
- update web manifest icon references
- finalize `Config.ensure_data_dir`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686723a38f98833397701321f2a7460d