### PR TITLE
Improve tooltip and label text

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -14,7 +14,7 @@
         <p class="text-xl text-gray-300 mb-8">The page you're looking for doesn't exist or has been moved.</p>
         <a href="{{ url_for('main.index') }}"
            class="btn btn--primary px-6 py-3 inline-block"
-           aria-label="Return to homepage">
+           aria-label="Return to homepage" title="Return to homepage">
             Return Home
         </a>
     </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -16,12 +16,12 @@
         <div class="flex justify-center space-x-4">
             <a href="{{ url_for('main.index') }}"
                class="btn btn--primary px-6 py-3"
-               aria-label="Return to homepage">
+               aria-label="Return to homepage" title="Return to homepage">
                 Return Home
             </a>
             <a href="mailto:support@rulescentral.com"
                class="btn btn--secondary px-6 py-3"
-               aria-label="Contact support">
+               aria-label="Contact support" title="Contact support">
                 Contact Support
             </a>
         </div>

--- a/templates/api_test_utility.html
+++ b/templates/api_test_utility.html
@@ -43,11 +43,11 @@
                               class="w-full px-4 py-3 rounded-xl bg-dark-800/60 border-2 border-slate-700/50 text-white placeholder-slate-400 focus:ring-accent-purple/30 focus:border-accent-purple/50 transition-all"></textarea>
                 </div>
                 <div class="flex justify-end gap-3">
-                    <button type="reset" class="px-6 py-3 rounded-lg font-medium bg-dark-700 text-gray-300 hover:bg-dark-600 transition-all flex items-center">
+                    <button type="reset" class="px-6 py-3 rounded-lg font-medium bg-dark-700 text-gray-300 hover:bg-dark-600 transition-all flex items-center" aria-label="Reset form" title="Reset form">
                         <i class="fas fa-redo mr-2"></i>
                         Reset
                     </button>
-                    <button type="submit" class="px-6 py-3 rounded-lg font-medium text-white bg-primary-500/20 border border-primary-500/30 hover:bg-primary-500/30 transition-all flex items-center">
+                    <button type="submit" class="px-6 py-3 rounded-lg font-medium text-white bg-primary-500/20 border border-primary-500/30 hover:bg-primary-500/30 transition-all flex items-center" aria-label="Send request" title="Send request">
                         <i class="fas fa-paper-plane mr-2"></i>
                         Send Request
                     </button>
@@ -62,7 +62,7 @@
                         <i class="fas fa-reply text-accent-purple mr-3"></i>
                         API Response
                     </h3>
-                    <button class="text-slate-400 hover:text-primary-400 transition-colors" id="closeResponsePanel" type="button">
+                    <button class="text-slate-400 hover:text-primary-400 transition-colors" id="closeResponsePanel" type="button" aria-label="Close response" title="Close response">
                         <i class="fas fa-times"></i>
                     </button>
                 </div>
@@ -105,7 +105,7 @@
     <!-- Floating Action Buttons -->
     <div class="fixed right-6 bottom-6 space-y-3 z-40">
         {% include 'partials/back_to_top.html' %}
-        <button aria-label="Help"
+        <button aria-label="Help" title="Open quick help"
                 class="w-12 h-12 bg-dark-800/60 text-slate-300 rounded-full shadow-lg hover:bg-dark-700/60 transition-colors flex items-center justify-center group"
                 id="helpButton">
             <i class="fas fa-question-circle group-hover:text-accent-purple"></i>
@@ -118,7 +118,7 @@
         <div class="bg-dark-800/95 border-2 border-slate-700/50 rounded-xl shadow-2xl backdrop-blur-lg max-w-md w-full p-6 animate-modalIn">
             <div class="flex justify-between items-center mb-4">
                 <h3 id="quickHelpTitle" class="text-lg font-bold text-white">API Test Utility Help</h3>
-                <button aria-label="Close help modal" class="text-slate-400 hover:text-white transition-colors"
+                <button aria-label="Close help modal" title="Close help" class="text-slate-400 hover:text-white transition-colors"
                         id="closeHelpModal">
                     <i class="fas fa-times"></i>
                 </button>

--- a/templates/help_system.html
+++ b/templates/help_system.html
@@ -2,7 +2,7 @@
     <!-- Help Button -->
     <button aria-controls="help-panel"
             aria-expanded="false"
-            aria-label="Open help menu"
+            aria-label="Open help menu" title="Open help menu"
             class="w-14 h-14 bg-gradient-to-br from-primary-500 to-accent-purple text-white rounded-full border border-white/5 shadow-lg hover:border-white/10 hover:shadow-2xl transition-all duration-300 ease-out flex items-center justify-center group relative overflow-hidden"
             id="help-button">
         <div class="absolute inset-0 bg-white/5 rounded-full scale-0 group-hover:scale-100 transition-transform duration-500"></div>
@@ -24,12 +24,12 @@
                 Help Center
             </h3>
             <div class="flex items-center space-x-3">
-                <button aria-label="Refresh help content"
+                <button aria-label="Refresh help content" title="Refresh help content"
                         class="text-white/80 hover:text-white transition-colors"
                         id="refresh-help">
                     <i class="fas fa-sync-alt"></i>
                 </button>
-                <button aria-label="Close help menu"
+                <button aria-label="Close help menu" title="Close help menu"
                         class="text-white/80 hover:text-white transition-colors"
                         id="close-help">
                     <i class="fas fa-times"></i>
@@ -47,7 +47,7 @@
                 <i class="fas fa-exclamation-triangle text-yellow-400 text-2xl mb-3"></i>
                 <p class="text-gray-300">Couldn't load help content</p>
                 <button class="mt-3 text-primary-400 hover:text-primary-300 text-sm flex items-center mx-auto transition-colors duration-200 group"
-                        id="retry-help">
+                        id="retry-help" aria-label="Retry loading help" title="Retry loading help">
                     <i class="fas fa-redo mr-2 text-sm group-hover:rotate-180 transition-transform"></i>
                     Try Again
                 </button>
@@ -58,12 +58,12 @@
         <div class="bg-dark-700/50 px-5 py-3 border-t border-dark-600/50 flex justify-between items-center">
             <div class="flex space-x-4">
                 <a class="text-primary-400 hover:text-primary-300 text-sm flex items-center transition-colors duration-200 group"
-                   href="/full-help">
+                   href="/full-help" title="Open full documentation">
                     <i class="fas fa-book-open mr-2 text-sm group-hover:translate-x-0.5 transition-transform"></i>
                     Full Documentation
                 </a>
                 <a class="text-primary-400 hover:text-primary-300 text-sm flex items-center transition-colors duration-200 group"
-                   href="/faq">
+                   href="/faq" title="Frequently asked questions">
                     <i class="fas fa-question-circle mr-2 text-sm group-hover:translate-x-0.5 transition-transform"></i>
                     FAQ
                 </a>

--- a/templates/partials/back_to_top.html
+++ b/templates/partials/back_to_top.html
@@ -1,4 +1,4 @@
-<button id="backToTop" aria-label="Back to top"
+<button id="backToTop" aria-label="Back to top" title="Back to top"
         class="back-to-top w-12 h-12 rounded-full flex items-center justify-center bg-gradient-to-r from-accent-purple to-primary-500 text-white shadow-lg transition-all duration-300 hover:from-accent-purple/80 hover:to-primary-500/80 hover:shadow-glow focus:outline-none focus-ring">
     <i class="fas fa-arrow-up"></i>
 </button>

--- a/templates/partials/hierarchy_viewer_body.html
+++ b/templates/partials/hierarchy_viewer_body.html
@@ -35,10 +35,10 @@ data-json="{{ url_for('routes.get_hierarchy_data',
             <div class="flex items-center justify-between text-xs text-slate-500">
                 <span id="match-counter">0 / 0</span>
                 <div class="space-x-2">
-                    <button id="prev-match" class="btn-icon" aria-label="Prev match">
+                    <button id="prev-match" class="btn-icon" aria-label="Prev match" title="Previous match">
                         <i class="fa-solid fa-chevron-up"></i>
                     </button>
-                    <button id="next-match" class="btn-icon" aria-label="Next match">
+                    <button id="next-match" class="btn-icon" aria-label="Next match" title="Next match">
                         <i class="fa-solid fa-chevron-down"></i>
                     </button>
                 </div>
@@ -171,15 +171,15 @@ data-json="{{ url_for('routes.get_hierarchy_data',
     <div id="floating-actions"
          class="flex flex-col items-end gap-2 opacity-0 translate-y-2 transition-all pointer-events-none">
         <button class="fab-btn floating-action-btn rounded-full bg-amber-500 text-dark-900
-                   w-14 h-14 shadow-lg" style="--i:1" aria-label="Export PNG">
+                   w-14 h-14 shadow-lg" style="--i:1" aria-label="Export PNG" title="Export as PNG">
             <i class="fa-solid fa-file-image text-xl"></i>
         </button>
         <button class="fab-btn floating-action-btn rounded-full bg-emerald-500 text-dark-900
-                   w-14 h-14 shadow-lg" style="--i:2" aria-label="Export PDF">
+                   w-14 h-14 shadow-lg" style="--i:2" aria-label="Export PDF" title="Export as PDF">
             <i class="fa-solid fa-file-pdf text-xl"></i>
         </button>
         <button class="fab-btn floating-action-btn rounded-full bg-sky-500 text-dark-900
-                   w-14 h-14 shadow-lg" style="--i:3" aria-label="Collapse All">
+                   w-14 h-14 shadow-lg" style="--i:3" aria-label="Collapse All" title="Collapse all nodes">
             <i class="fa-solid fa-compress text-xl"></i>
         </button>
     </div>
@@ -187,7 +187,7 @@ data-json="{{ url_for('routes.get_hierarchy_data',
     <button id="floating-menu-trigger"
             class="rounded-full bg-sky-600 text-white w-16 h-16 shadow-xl
                  flex items-center justify-center text-2xl transition-transform
-                 hover:rotate-90" aria-label="More actions">
+                 hover:rotate-90" aria-label="More actions" title="More actions">
         <i class="fa-solid fa-plus"></i>
     </button>
 </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -20,7 +20,7 @@ Curate your profile for a personalized touch.
             <div class="absolute -bottom-20 left-8">
                 <div class="relative group">
                     <div class="h-40 w-40 rounded-full border-4 border-white dark:border-dark-800 bg-white dark:bg-dark-700 overflow-hidden shadow-xl">
-                        <img class="h-full w-full object-cover" src="{{ user.avatar }}">
+                        <img class="h-full w-full object-cover" src="{{ user.avatar }}" alt="{{ user.username }} avatar">
                     </div>
                     <div class="absolute inset-0 rounded-full bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                         <button class="p-2 bg-white/80 rounded-full text-primary-600 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500">


### PR DESCRIPTION
## Summary
- add alt text for avatar on profile page
- improve tooltips and aria hints in help system
- add accessibility titles to API tester buttons
- add titles for search navigation buttons and floating action buttons
- add titles to error page links

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68672c310fe883339f5631453039d7ec