### PR TITLE
Improve config handling and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ It provides tools to upload diagrams, analyze rules, and collaborate with others
 - Python 3.10+
 - Node.js for building Tailwind CSS assets
 
-Install Python dependencies:
+Install Python dependencies (or install the package in editable mode):
 ```bash
 pip install -r requirements.txt
+# or
+pip install -e .
 ```
 
 Build CSS assets (optional):
@@ -30,6 +32,10 @@ Use Flask's built‑in server to start the app:
 python app.py
 ```
 Then open [http://127.0.0.1:8080](http://127.0.0.1:8080) in your browser.
+
+### Custom configuration
+Set the ``CONFIG_PATH`` environment variable to load an alternative
+``config.json`` file when running the app or tests.
 
 ## Project structure
 - `app.py` – application factory

--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+"""Application factory and runtime setup for Rules Central."""
+
 import logging
 import os
 from datetime import datetime, timezone
@@ -70,7 +72,10 @@ def create_app() -> Flask:
 
     # ─── Blueprints & Config ───────────────────────────────────────
     app.register_blueprint(routes_bp)
-    app.config.update(load_configurations())
+    try:
+        app.config.update(load_configurations())
+    except Exception as exc:  # pragma: no cover - config errors rarely occur
+        app.logger.error("Configuration load failed: %s", exc)
 
     return app
 

--- a/config.py
+++ b/config.py
@@ -1,27 +1,40 @@
 import json
+"""Configuration loading utilities for Rules Central."""
+
+import json
 import logging
 import os
 from pathlib import Path
 from datetime import datetime
 
-CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config', 'config.json')
+# Allow overriding the configuration file path via the ``CONFIG_PATH``
+# environment variable for flexible deployments.
+CONFIG_PATH = os.environ.get(
+    "CONFIG_PATH",
+    os.path.join(os.path.dirname(__file__), "config", "config.json"),
+)
 
 
 def load_configurations():
+    """Load configuration data from :data:`CONFIG_PATH`."""
+
     try:
-        with open(CONFIG_PATH, 'r', encoding="utf-8") as config_file:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as config_file:
             return json.load(config_file)
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        logging.error(f"Error loading configuration file: {e}")
-        return {'translations': {}, 'styles': {}}
+    except (FileNotFoundError, json.JSONDecodeError) as err:
+        logging.error("Error loading configuration file: %s", err)
+        return {"translations": {}, "styles": {}}
 
 
 class Config:
-    DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
-    ACTIVITY_LOG = Path(DATA_DIR) / 'activity_log.json'
+    """Application configuration constants and helpers."""
+
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+    ACTIVITY_LOG = Path(DATA_DIR) / "activity_log.json"
 
     @classmethod
     def ensure_data_dir(cls):
+        """Ensure the data directory and activity log exist."""
         os.makedirs(cls.DATA_DIR, exist_ok=True)
         if not cls.ACTIVITY_LOG.exists():
             initial_data = {
@@ -35,7 +48,7 @@ class Config:
                     }
                 ]
             }
-            with open(cls.ACTIVITY_LOG, 'w') as f:
+            with open(cls.ACTIVITY_LOG, "w", encoding="utf-8") as f:
                 json.dump(initial_data, f, indent=2)
             cls.ACTIVITY_LOG.chmod(0o644)
         return cls.ACTIVITY_LOG

--- a/extensions.py
+++ b/extensions.py
@@ -1,12 +1,24 @@
+"""Flask extension initialization module."""
+
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_migrate import Migrate
 
+# Instantiate the core extensions. These will be initialized with the Flask
+# application in the factory defined in ``app.py``.
 db = SQLAlchemy()
 login_manager = LoginManager()
 migrate = Migrate()
 
 @login_manager.user_loader
 def load_user(user_id):
+    """Return the user instance associated with ``user_id``."""
+
     from models import User
-    return User.query.get(int(user_id))
+
+    try:
+        return User.query.get(int(user_id))
+    except (ValueError, TypeError):
+        # Log at debug level since invalid IDs should be rare and non-fatal
+        login_manager.logger.debug("Invalid user id: %s", user_id)
+        return None

--- a/models.py
+++ b/models.py
@@ -1,8 +1,12 @@
+"""Database models for the Rules Central application."""
+
 from extensions import db
 from flask_login import UserMixin
 
 
 class User(db.Model, UserMixin):
+    """Application user model."""
+
     __tablename__ = 'users'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -12,10 +16,14 @@ class User(db.Model, UserMixin):
     is_active = db.Column(db.Boolean, default=True)
 
     def get_id(self):
+        """Return the user's id as a string."""
+
         return str(self.id)
 
 
 class Diagram(db.Model):
+    """Stored diagram metadata."""
+
     __tablename__ = 'diagrams'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -27,4 +35,5 @@ class Diagram(db.Model):
     updated_at = db.Column(db.DateTime, default=db.func.current_timestamp(),
                            onupdate=db.func.current_timestamp())
 
+    # Relationship back to the owning :class:`User`
     user = db.relationship('User', backref='diagrams')

--- a/routes/api.py
+++ b/routes/api.py
@@ -1,10 +1,16 @@
-# routes/api.py
-from flask import Blueprint, jsonify
+"""Minimal API endpoints."""
+
+from flask import Blueprint, jsonify, current_app
 
 api = Blueprint('api', __name__)
 
 @api.route('/api/catalog_names')
 def catalog_names():
-    # Replace with your actual catalog names source
-    names = ['Catalog1', 'Catalog2', 'Catalog3']
-    return jsonify(names)
+    """Return available catalog names."""
+
+    try:
+        names = ['Catalog1', 'Catalog2', 'Catalog3']
+        return jsonify(names)
+    except Exception as exc:
+        current_app.logger.error("Catalog names error: %s", exc)
+        return jsonify(error="Failed to fetch names"), 500

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,7 +1,15 @@
-from flask import Blueprint
+"""Authentication routes."""
+
+from flask import Blueprint, current_app, jsonify
 
 auth = Blueprint('auth', __name__)
 
 @auth.route('/login')
 def login():
-    return "Login Page"
+    """Simple login endpoint placeholder."""
+
+    try:
+        return "Login Page"
+    except Exception as exc:
+        current_app.logger.error("Login route error: %s", exc)
+        return jsonify(error="Login failure"), 500

--- a/routes/collab.py
+++ b/routes/collab.py
@@ -1,7 +1,15 @@
-from flask import Blueprint
+"""Collaboration routes."""
+
+from flask import Blueprint, current_app, jsonify
 
 collab = Blueprint('collab', __name__)
 
 @collab.route('/collab')
 def collab_index():
-    return "Collaboration Home"
+    """Placeholder collaboration page."""
+
+    try:
+        return "Collaboration Home"
+    except Exception as exc:
+        current_app.logger.error("Collab route error: %s", exc)
+        return jsonify(error="Collaboration service unavailable"), 500

--- a/routes/diagrams.py
+++ b/routes/diagrams.py
@@ -1,7 +1,15 @@
-from flask import Blueprint
+"""Simple diagrams route placeholder."""
+
+from flask import Blueprint, current_app, jsonify
 
 diagrams = Blueprint('diagrams', __name__)
 
 @diagrams.route('/diagrams')
 def diagrams_index():
-    return "Diagrams Home"
+    """Return a placeholder message for diagrams."""
+
+    try:
+        return "Diagrams Home"
+    except Exception as exc:
+        current_app.logger.error("Diagrams route error: %s", exc)
+        return jsonify(error="Unable to load diagrams"), 500

--- a/routes/main.py
+++ b/routes/main.py
@@ -1,15 +1,35 @@
-from flask import Blueprint, render_template
+"""Main user-facing pages."""
+
+from flask import Blueprint, render_template, current_app, abort
 
 main = Blueprint('main', __name__)
 
 @main.route('/')
 def index():
-    return render_template('index.html')
+    """Render the application home page."""
+
+    try:
+        return render_template('index.html')
+    except Exception as exc:
+        current_app.logger.error("Index page error: %s", exc)
+        abort(500)
 
 @main.route('/catalog')
 def catalog():
-    return render_template('catalog.html')
+    """Display the diagram catalog."""
+
+    try:
+        return render_template('catalog.html')
+    except Exception as exc:
+        current_app.logger.error("Catalog page error: %s", exc)
+        abort(500)
 
 @main.route('/search')
 def search():
-    return render_template('search.html')
+    """Display the search page."""
+
+    try:
+        return render_template('search.html')
+    except Exception as exc:
+        current_app.logger.error("Search page error: %s", exc)
+        abort(500)

--- a/routes/upload.py
+++ b/routes/upload.py
@@ -1,5 +1,16 @@
+"""Routes for file uploads and diagram generation."""
+
 import os
-from flask import Blueprint, current_app, request, redirect, url_for, flash, render_template, jsonify
+from flask import (
+    Blueprint,
+    current_app,
+    request,
+    redirect,
+    url_for,
+    flash,
+    render_template,
+    jsonify,
+)
 from werkzeug.utils import secure_filename
 from utils import (
     allowed_file,
@@ -12,6 +23,8 @@ upload = Blueprint('upload', __name__)
 
 @upload.route('/upload', methods=['GET', 'POST'])
 def upload_file():
+    """Handle file uploads and generate diagrams."""
+
     if request.method == 'GET':
         return render_template('upload.html', help_available=True)
 

--- a/service.py
+++ b/service.py
@@ -1,3 +1,6 @@
+"""Windows service wrapper for running the Flask app with Waitress."""
+
+import logging
 import win32serviceutil
 import win32service
 import win32event
@@ -6,12 +9,14 @@ from waitress import serve
 from app import app  # Import your Flask app from your app module
 
 class WaitressService(win32serviceutil.ServiceFramework):
+    """Run the Flask application as a Windows service via Waitress."""
+
     _svc_name_ = "WaitressService"
     _svc_display_name_ = "Waitress Service for Rules Central Flask App"
     _svc_description_ = "Runs a Flask application with Waitress as a Windows Service."
 
     def __init__(self, args):
-        win32serviceutil.ServiceFramework.__init__(self, args)
+        super().__init__(args)
         self.hWaitStop = win32event.CreateEvent(None, 0, 0, None)
 
     def SvcStop(self):
@@ -19,14 +24,22 @@ class WaitressService(win32serviceutil.ServiceFramework):
         win32event.SetEvent(self.hWaitStop)
 
     def SvcDoRun(self):
-        # Log the service start event
-        servicemanager.LogMsg(servicemanager.EVENTLOG_INFORMATION_TYPE,
-                              servicemanager.PYS_SERVICE_STARTED,
-                              (self._svc_name_, ''))
-        # Start Waitress. This call will block until the service is stopped.
-        serve(app, host="0.0.0.0", port=8081)
-        # Wait until the stop signal is received
-        win32event.WaitForSingleObject(self.hWaitStop, win32event.INFINITE)
+        """Entry point for the service when started by Windows."""
+
+        servicemanager.LogMsg(
+            servicemanager.EVENTLOG_INFORMATION_TYPE,
+            servicemanager.PYS_SERVICE_STARTED,
+            (self._svc_name_, "")
+        )
+
+        try:
+            # Start Waitress. This call blocks until the service is stopped.
+            serve(app, host="0.0.0.0", port=8081)
+        except Exception as exc:  # pragma: no cover - platform specific
+            logging.exception("Waitress service failed: %s", exc)
+        finally:
+            # Wait until the stop signal is received
+            win32event.WaitForSingleObject(self.hWaitStop, win32event.INFINITE)
 
 if __name__ == '__main__':
     win32serviceutil.HandleCommandLine(WaitressService)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,18 @@
+"""Packaging script for Rules Central."""
+
 from pathlib import Path
 from setuptools import setup, find_packages
+
+
+def parse_requirements(path: Path) -> list[str]:
+    """Return a clean list of requirements from the given file."""
+
+    with path.open() as req:
+        return [
+            line.strip()
+            for line in req
+            if line.strip() and not line.startswith("#")
+        ]
 
 BASE_DIR = Path(__file__).parent
 README = (BASE_DIR / "README.md").read_text(encoding="utf-8")
@@ -8,10 +21,7 @@ setup(
     name="rules_central",
     version="0.1",
     packages=find_packages(),
-    install_requires=[
-        "flask",
-        "flask-sqlalchemy",
-    ],
+    install_requires=parse_requirements(BASE_DIR / "requirements.txt"),
     long_description=README,
     long_description_content_type="text/markdown",
 )

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,7 @@
+"""WSGI entry point for production servers."""
+
 from app import app
 
 if __name__ == "__main__":
+    # Run with Flask's development server when executed directly.
     app.run()


### PR DESCRIPTION
## Summary
- allow custom CONFIG_PATH in config module
- wrap config loading in `create_app`
- load install requirements from requirements.txt in setup script
- document optional editable install and custom config path

## Testing
- `python -m py_compile extensions.py models.py service.py wsgi.py routes/auth.py routes/main.py routes/upload.py routes/collab.py routes/api.py routes/diagrams.py app.py all_routes.py utils.py config.py setup.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68673e03f3f0833392b26a0f806a35cd