### PR TITLE
Add about page and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It provides tools to upload diagrams, analyze rules, and collaborate with others
 - **Upload** diagrams with validation
 - **Search** and explore stored rules
 - **API utility** for testing rules
+- **About** page with version info and documentation links
 
 ## Requirements
 - Python 3.10+
@@ -32,6 +33,7 @@ Use Flask's built‑in server to start the app:
 python app.py
 ```
 Then open [http://127.0.0.1:8080](http://127.0.0.1:8080) in your browser.
+You can also visit [/about](http://127.0.0.1:8080/about) to view the running version and helpful links.
 
 ### Custom configuration
 Set the ``CONFIG_PATH`` environment variable to load an alternative

--- a/routes/main.py
+++ b/routes/main.py
@@ -33,3 +33,15 @@ def search():
     except Exception as exc:
         current_app.logger.error("Search page error: %s", exc)
         abort(500)
+
+
+@main.route('/about')
+def about():
+    """Display project information and version."""
+
+    try:
+        version = current_app.config.get("VERSION", "1.0")
+        return render_template('about.html', version=version)
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        current_app.logger.error("About page error: %s", exc)
+        abort(500)

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block title %}About – Rules Central{% endblock %}
+
+{% block hero_title %}About Rules Central{% endblock %}
+{% block hero_subtitle %}Learn more about this project{% endblock %}
+
+{% block content %}
+<section class="container mx-auto px-4 py-12 max-w-3xl" aria-label="About Rules Central">
+    <div class="prose prose-slate dark:prose-invert">
+        <h2>Version {{ version }}</h2>
+        <p>Rules Central is a Flask-based platform for managing and visualizing rule sets.</p>
+        <p>It allows teams to upload diagrams, analyze results and collaborate efficiently.</p>
+        <ul>
+            <li>Diagram catalog with quick search</li>
+            <li>Upload validation and diagram generation</li>
+            <li>API utilities for testing rule logic</li>
+        </ul>
+        <p>For comprehensive guides visit the <a href="/full-help">documentation</a>.</p>
+    </div>
+</section>
+{% endblock %}

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -41,6 +41,10 @@
                     <span class="relative z-10 flex items-center"><i class="fas fa-code-branch mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>Rules Extraction</span>
                     <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
                 </a>
+                <a class="relative px-4 py-2.5 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all duration-300 group" href="/about">
+                    <span class="relative z-10 flex items-center"><i class="fas fa-info-circle mr-2 text-sm opacity-80 group-hover:opacity-100 transition-opacity"></i>About</span>
+                    <span class="absolute bottom-0 left-1/2 w-0 h-0.5 bg-gradient-to-r from-primary-500 to-accent-purple transition-all duration-300 group-hover:w-4/5 group-hover:left-[10%]"></span>
+                </a>
             </nav>
 
             <!-- Right Side Controls -->
@@ -104,6 +108,11 @@
             <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="/rules_extraction_utility">
                 <i class="fas fa-code-branch mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
                 <span>Rules Extraction</span>
+                <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
+            </a>
+            <a class="flex items-center text-gray-600 dark:text-slate-300 py-3 px-4 hover:bg-gray-100 dark:hover:bg-dark-700/50 rounded-lg transition-all duration-300 hover:text-gray-900 dark:hover:text-white hover:pl-6 group" href="/about">
+                <i class="fas fa-info-circle mr-3 text-primary-500/80 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
+                <span>About</span>
                 <i class="fas fa-chevron-right ml-auto text-xs text-gray-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors"></i>
             </a>
         </div>


### PR DESCRIPTION
## Summary
- add `/about` route with template showing project info
- link to about page in navigation
- document the about page in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686740d3fbcc83338498045e4a68dee1