### PR TITLE
Add codespaces dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "Rules Central Dev Container",
+    "image": "mcr.microsoft.com/devcontainers/python:3.11",
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "18"
+        }
+    },
+    "postCreateCommand": "pip install -r requirements.txt && npm install && npm run build:css",
+    "forwardPorts": [8080]
+}

--- a/README.md
+++ b/README.md
@@ -46,5 +46,13 @@ Set the ``CONFIG_PATH`` environment variable to load an alternative
 - `templates/` – Jinja2 templates
 - `static/` – static assets
 
+## Codespaces
+
+This project includes a development container configuration for GitHub Codespaces. The container installs Python dependencies and builds the CSS assets for you. Once the container is ready, start the app with:
+```bash
+python app.py
+```
+The site will be available at http://127.0.0.1:8080.
+
 ## License
 This project is provided as‑is without warranty.


### PR DESCRIPTION
## Summary
- add `.devcontainer/devcontainer.json` for Python and Node
- document how to use the dev container

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68674206578c8333a4b9f5841165308d