### PR TITLE
Add codespaces auto start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "Rules Central Dev Container",
+    "image": "mcr.microsoft.com/devcontainers/python:3.11",
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "18"
+        }
+    },
+    "postCreateCommand": "pip install -r requirements.txt && npm install && npm run build:css",
+    "postStartCommand": "python -u app.py",
+    "forwardPorts": [8080],
+    "portsAttributes": {
+        "8080": {
+            "label": "Web Application",
+            "onAutoForward": "openBrowser"
+        }
+    },
+    "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -46,5 +46,15 @@ Set the ``CONFIG_PATH`` environment variable to load an alternative
 - `templates/` – Jinja2 templates
 - `static/` – static assets
 
+## Codespaces
+
+Open this repository in GitHub Codespaces to develop in a pre-configured container.
+The `postCreateCommand` installs Python requirements, installs npm packages, and
+builds the Tailwind CSS assets automatically. When the codespace launches the
+`postStartCommand` runs `python app.py`, so the site starts automatically.
+
+Port `8080` is forwarded automatically and will open in your browser when the
+server starts.
+
 ## License
 This project is provided as‑is without warranty.


### PR DESCRIPTION
## Summary
- refine devcontainer with `postStartCommand` to automatically run the app
- document that the server starts automatically in Codespaces

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68674206578c8333a4b9f5841165308d