### PR TITLE
Enhance base template with PWA support

### DIFF
--- a/static/js/service-worker.js
+++ b/static/js/service-worker.js
@@ -1,0 +1,34 @@
+const CACHE_NAME = 'rules-central-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/static/css/tailwind.css',
+  '/static/css/main.css',
+  '/static/css/overhaul.css',
+  '/static/js/app.js',
+  '/static/js/app-utils.js',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(URLS_TO_CACHE))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,17 @@
   <meta name="description" content="Rules Central – a comprehensive rules-management system">
   <meta name="theme-color" content="#0f172a">
 
+  <link rel="manifest" href="{{ url_for('static', filename='site.webmanifest') }}">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
+  {% block meta %}
+  <meta property="og:title" content="Rules Central">
+  <meta property="og:description" content="Rules Central – a comprehensive rules-management system">
+  <meta property="og:image" content="{{ url_for('static', filename='images/RulesCentralLogo.png') }}">
+  <meta name="twitter:card" content="summary_large_image">
+  {% endblock %}
+
   <title>{% block title %}Rules Central{% endblock %}</title>
   <link rel="icon" href="{{ url_for('static', filename='images/favicon.ico') }}" type="image/x-icon">
 
@@ -112,6 +123,15 @@
   <script defer src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
   <script defer src="{{ url_for('static', filename='js/app-utils.js') }}"></script>
   <script defer src="{{ url_for('static', filename='js/app.js') }}"></script>
+
+  <!-- Service Worker Registration -->
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('{{ url_for('static', filename='js/service-worker.js') }}');
+      });
+    }
+  </script>
 
   <!-- Theme management -->
   <script>


### PR DESCRIPTION
## Summary
- add service worker and register it in base template
- expose manifest and social meta tags for better sharing and offline capability

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867cfdd6da8833380e5e96983b536d9