### PR TITLE
Enhance theme configuration page

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -113,6 +113,18 @@ Diagram Theme Manager – Rules Central
                             </button>
                         </div>
 
+                        <!-- Expand/Collapse Controls -->
+                        <div class="flex items-center justify-between mb-4">
+                            <div class="flex gap-2">
+                                <button class="text-xs text-purple-300 hover:underline transition-colors" id="expandAllBtn">
+                                    Expand all
+                                </button>
+                                <button class="text-xs text-purple-300 hover:underline transition-colors" id="collapseAllBtn">
+                                    Collapse all
+                                </button>
+                            </div>
+                        </div>
+
                         <!-- Results Container with Expand/Collapse -->
                         <div class="space-y-2 max-h-[500px] overflow-y-auto custom-scroll" id="themeList">
                             <!-- Grouped Results Example -->
@@ -189,7 +201,7 @@ Diagram Theme Manager – Rules Central
                                 <i class="fas fa-sliders-h text-teal-300 mr-2 hover-float"></i>
                                 <span id="currentThemeTitle">Theme Editor</span>
                             </h2>
-                            <div class="flex gap-3">
+                            <div class="flex flex-wrap justify-end gap-3">
                                 <button aria-label="Duplicate theme"
                                         class="px-4 py-2 bg-gray-800/50 hover:bg-gray-700/50 text-gray-300 border-2 border-gray-700/50 hover:border-purple-500/50 rounded-xl text-sm transition-colors flex items-center" id="duplicateThemeBtn">
                                     <i class="fas fa-copy mr-2"></i> Duplicate
@@ -201,6 +213,19 @@ Diagram Theme Manager – Rules Central
                                 <button aria-label="Delete theme"
                                         class="px-4 py-2 bg-red-500/10 hover:bg-red-500/20 text-red-300 border-2 border-red-500/50 hover:border-red-400/50 rounded-xl text-sm transition-colors flex items-center" id="deleteThemeBtn">
                                     <i class="fas fa-trash-alt mr-2"></i> Delete
+                                </button>
+                                <button aria-label="Import themes"
+                                        class="px-4 py-2 bg-gray-800/50 hover:bg-gray-700/50 text-gray-300 border-2 border-gray-700/50 hover:border-purple-500/50 rounded-xl text-sm transition-colors flex items-center" id="importBtn">
+                                    <i class="fas fa-file-import mr-2"></i> Import
+                                </button>
+                                <input id="importFile" type="file" accept="application/json" class="hidden" />
+                                <button aria-label="Export themes"
+                                        class="px-4 py-2 bg-gray-800/50 hover:bg-gray-700/50 text-gray-300 border-2 border-gray-700/50 hover:border-purple-500/50 rounded-xl text-sm transition-colors flex items-center" id="exportBtn">
+                                    <i class="fas fa-file-export mr-2"></i> Export
+                                </button>
+                                <button aria-label="Save theme"
+                                        class="px-4 py-2 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-xl text-sm transition-colors hover:from-purple-700 hover:to-blue-700 flex items-center" id="saveBtn">
+                                    <i class="fas fa-save mr-2"></i> Save Changes
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- add import/export/save controls to config template
- provide expand/collapse buttons for theme groups

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867dcb70708833383f6248b0b54ee54