### PR TITLE
Fix anchor styles

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -16,7 +16,7 @@
             <li>Upload validation and diagram generation</li>
             <li>API utilities for testing rule logic</li>
         </ul>
-        <p>For comprehensive guides visit the <a href="/full-help">documentation</a>.</p>
+        <p>For comprehensive guides visit the <a href="/full-help" class="text-primary-400 hover:underline">documentation</a>.</p>
     </div>
 </section>
 {% endblock %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -9,7 +9,7 @@
 <section class="container mx-auto px-4 py-12 max-w-xl" aria-label="Contact Rules Central">
     <div class="prose prose-slate dark:prose-invert">
         <p class="mb-6">Fill out the form below or email
-            <a href="mailto:support@rulescentral.com">support@rulescentral.com</a>.
+            <a href="mailto:support@rulescentral.com" class="text-primary-400 hover:underline">support@rulescentral.com</a>.
         </p>
         <form action="mailto:support@rulescentral.com" method="post" class="space-y-4">
             <div>


### PR DESCRIPTION
## Summary
- ensure consistent link styling in documentation link on About page
- add link styling for contact email

## Testing
- `pytest -q`
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68683606a19c8333a973b5c286f6b54c