### PR TITLE
Enhance navigation styling

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1917,3 +1917,48 @@ body {
   font-size: 3rem;
   margin-bottom: 1rem;
 }
+/* Enhanced navigation link styles */
+.nav-link {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--slate-600);
+  transition: background-color var(--transition-speed), color var(--transition-speed);
+}
+.nav-link:hover,
+.nav-link:focus {
+  color: var(--primary-500);
+  background-color: rgba(59, 130, 246, 0.1);
+}
+html.dark .nav-link {
+  color: var(--slate-300);
+}
+html.dark .nav-link:hover,
+html.dark .nav-link:focus {
+  color: var(--primary-400);
+  background-color: rgba(30, 41, 59, 0.8);
+}
+.mobile-nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: var(--slate-700);
+  transition: background-color var(--transition-speed), color var(--transition-speed);
+}
+.mobile-nav-link:hover,
+.mobile-nav-link:focus {
+  background-color: rgba(59, 130, 246, 0.1);
+  color: var(--primary-600);
+}
+html.dark .mobile-nav-link {
+  color: var(--slate-300);
+}
+html.dark .mobile-nav-link:hover,
+html.dark .mobile-nav-link:focus {
+  background-color: rgba(30, 41, 59, 0.8);
+  color: var(--primary-400);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -79,7 +79,7 @@
 
   <main id="main-content" class="flex-grow flex flex-col" tabindex="-1">
     {% block hero %}
-    <section class="hero-section relative overflow-hidden bg-gradient-to-br from-primary-900 via-dark-800 to-dark-700 py-24">
+    <section class="hero-section relative overflow-hidden bg-gradient-to-br from-primary-800 via-accent-purple/20 to-dark-700 py-24">
       <div class="particles absolute inset-0 overflow-hidden pointer-events-none -z-10">
         {% for i in range(15) %}
         <div class="particle" style="--size: {{ (0.5 + random() * 2)|round(2) }}px; --x: {{ random() * 100 }}%; --y: {{ random() * 100 }}%; --delay: {{ random() * 5 }}s; --duration: {{ 10 + random() * 20 }}s;"></div>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -1,4 +1,4 @@
-<header class="bg-white/90 dark:bg-dark-900/90 backdrop-blur-xl border-b border-gray-200/80 dark:border-slate-800/60 fixed w-full z-50 shadow-sm hover:shadow-md transition-all duration-300">
+<header class="bg-gradient-to-r from-white/80 to-white/90 dark:from-dark-900/95 dark:to-dark-800/90 backdrop-blur-xl border-b border-gray-200/80 dark:border-slate-800/60 fixed w-full z-50 shadow-sm hover:shadow-md transition-all duration-300">
     <div class="container mx-auto px-4 sm:px-6">
         <div class="flex items-center justify-between h-16">
             <!-- Logo (Improved hover effect & accessibility) -->


### PR DESCRIPTION
## Summary
- improve hero gradient colors
- add gradient background to header
- style nav links with CSS for smoother transitions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab586d00c83338ba00282d36a1554