### PR TITLE
Improve auth page styling

### DIFF
--- a/static/css/overhaul.css
+++ b/static/css/overhaul.css
@@ -133,6 +133,14 @@ h1, h2, h3, h4 {
   margin-bottom: 1.2em;
 }
 
+/* Auth card styling */
+.auth-card {
+  background: rgba(31,41,55,0.8);
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 15px 30px rgba(0,0,0,0.3), 0 4px 6px rgba(0,0,0,0.2);
+  backdrop-filter: blur(12px);
+}
+
 @media (max-width: 700px) {
   .dashboard-card { padding: 1rem 0.5rem; }
   h1 { font-size: 2rem; }

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -2,6 +2,9 @@
 
 {% block title %}Login - Rules Central{% endblock %}
 
+{% block hero_title %}Sign In{% endblock %}
+{% block hero_subtitle %}Access your account to manage rules{% endblock %}
+
 {% block content %}
 <div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg auth-card">
     <div class="text-center mb-4 text-primary-400">

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -2,6 +2,9 @@
 
 {% block title %}Register - Rules Central{% endblock %}
 
+{% block hero_title %}Create Account{% endblock %}
+{% block hero_subtitle %}Join Rules Central and collaborate{% endblock %}
+
 {% block content %}
 <div class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg auth-card">
     <div class="text-center mb-4 text-primary-400">


### PR DESCRIPTION
## Summary
- give Login/Register pages custom hero text
- style auth card with glass-like look

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aba59fac8833387fa46dd731b5c68