### PR TITLE
Fix help panel flash on load

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -13,6 +13,11 @@
   --transition-speed: 0.25s;
 }
 
+/* Hide Alpine.js elements until initialized */
+[x-cloak] {
+  display: none !important;
+}
+
 body, html {
   margin: 0;
   padding: 0;
@@ -36,6 +41,10 @@ body, html {
 @keyframes fadeInPanel {
   from { opacity: 0; transform: translateY(24px) scale(0.98);}
   to   { opacity: 1; transform: none;}
+}
+
+.animate-fadeIn {
+  animation: fadeInPanel 0.6s ease-out;
 }
 
 .panel::before, .card::before, .bg-panel::before {

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -116,8 +116,9 @@
         <i class="fas fa-question relative z-10 transform transition-all duration-300" :class="{'rotate-12 scale-110': open}"></i>
         <span class="sr-only">Help</span>
     </button>
-    <div 
+    <div
         x-show="open"
+        x-cloak
         x-transition:enter="transition ease-out duration-200"
         x-transition:enter-start="opacity-0 translate-y-2"
         x-transition:enter-end="opacity-100 translate-y-0"
@@ -125,7 +126,7 @@
         x-transition:leave-start="opacity-100 translate-y-0"
         x-transition:leave-end="opacity-0 translate-y-2"
         class="absolute bottom-full right-0 mb-6 w-96 bg-dark-800/95 backdrop-blur-2xl rounded-2xl shadow-2xl overflow-hidden border border-dark-700/60 animate-fadeIn"
-        id="help-panel" 
+        id="help-panel"
         style="z-index: 10000;"
         @click.away="open = false">
         <div class="bg-gradient-to-r from-primary-600 to-primary-700 text-white px-7 py-5 flex items-center justify-between">


### PR DESCRIPTION
## Summary
- hide help panel until Alpine initializes
- add rule for `[x-cloak]` to main CSS
- add fade-in animation helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abf1302488333b73c4ab5cc6f668c