### PR TITLE
Add hero blocks to templates

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% block title %}404 Not Found | Rules Central{% endblock %}
 
+{% block hero_title %}Page Not Found{% endblock %}
+{% block hero_subtitle %}Sorry, the page you’re looking for doesn’t exist or has been moved. Let’s get you back on track!{% endblock %}
+
 {% block content %}
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[60vh] py-16 animate-fadeIn">
+<section class="relative z-10 flex flex-col items-center justify-center py-16 animate-fadeIn">
   <div class="flex flex-col items-center">
     <svg class="w-40 h-40 mb-8 animate-bounce-slow" fill="none" viewBox="0 0 200 200"><ellipse cx="100" cy="100" rx="90" ry="60" fill="#6366f1" fill-opacity="0.15"/><ellipse cx="100" cy="120" rx="60" ry="30" fill="#a78bfa" fill-opacity="0.18"/><text x="50%" y="54%" text-anchor="middle" fill="#fff" font-size="64" font-weight="bold" dy=".3em">404</text></svg>
-    <h1 class="text-5xl font-extrabold text-primary-500 mb-4 text-center">Page Not Found</h1>
-    <p class="text-lg text-slate-300 mb-8 text-center max-w-xl">Sorry, the page you’re looking for doesn’t exist or has been moved. Let’s get you back on track!</p>
     <a href="/" class="inline-block px-8 py-4 rounded-xl bg-gradient-to-r from-primary-500 to-accent-purple text-white font-bold shadow-xl hover:scale-105 hover:shadow-2xl transition-all text-lg focus:outline-none focus:ring-4 focus:ring-primary-500">Return Home</a>
   </div>
 </section>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% block title %}500 Server Error | Rules Central{% endblock %}
 
+{% block hero_title %}Server Error{% endblock %}
+{% block hero_subtitle %}Oops! Something went wrong on our end. Please try again later or contact support if the issue persists.{% endblock %}
+
 {% block content %}
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[60vh] py-16 animate-fadeIn">
+<section class="relative z-10 flex flex-col items-center justify-center py-16 animate-fadeIn">
   <div class="flex flex-col items-center">
     <svg class="w-40 h-40 mb-8 animate-pulse" fill="none" viewBox="0 0 200 200"><ellipse cx="100" cy="100" rx="90" ry="60" fill="#f472b6" fill-opacity="0.15"/><ellipse cx="100" cy="120" rx="60" ry="30" fill="#6366f1" fill-opacity="0.18"/><text x="50%" y="54%" text-anchor="middle" fill="#fff" font-size="64" font-weight="bold" dy=".3em">500</text></svg>
-    <h1 class="text-5xl font-extrabold text-accent-purple mb-4 text-center">Server Error</h1>
-    <p class="text-lg text-slate-300 mb-8 text-center max-w-xl">Oops! Something went wrong on our end. Please try again later or contact support if the issue persists.</p>
     <a href="/" class="inline-block px-8 py-4 rounded-xl bg-gradient-to-r from-primary-500 to-accent-purple text-white font-bold shadow-xl hover:scale-105 hover:shadow-2xl transition-all text-lg focus:outline-none focus:ring-4 focus:ring-primary-500">Return Home</a>
   </div>
 </section>

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,12 +1,10 @@
 {% extends "base.html" %}
 {% block title %}About | Rules Central{% endblock %}
 
+{% block hero_title %}About Rules Central{% endblock %}
+{% block hero_subtitle %}Your comprehensive platform for managing, visualizing, and collaborating on business rules and logic.{% endblock %}
+
 {% block content %}
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[40vh] py-12 animate-fadeIn">
-  <h1 class="text-4xl font-extrabold mb-4 text-primary-500 text-center animate-fadeIn">About Rules Central</h1>
-  <p class="text-lg text-slate-300 mb-10 text-center max-w-2xl animate-fadeIn delay-100">Your comprehensive platform for managing, visualizing, and collaborating on business rules and logic.</p>
-</section>
 <div class="flex flex-col items-center justify-center animate-fadeIn delay-200">
   <div class="bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-2xl glassmorphism flex flex-col items-center">
     <div class="flex gap-6 mb-8">

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,21 @@
 </head>
 <body class="bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 min-h-screen font-sans text-white">
   {% include 'partials/header.html' %}
+  {% if self.hero_title().strip() or self.hero_subtitle().strip() %}
+  <section class="relative flex flex-col items-center justify-center text-center min-h-[40vh] py-12">
+    {% include 'partials/hero_bg.html' %}
+    <div class="relative z-10">
+      <h1 class="text-4xl font-extrabold mb-4 text-primary-500">
+        {% block hero_title %}{% endblock %}
+      </h1>
+      {% if self.hero_subtitle().strip() %}
+      <p class="text-lg text-slate-300 max-w-2xl mx-auto">
+        {% block hero_subtitle %}{% endblock %}
+      </p>
+      {% endif %}
+    </div>
+  </section>
+  {% endif %}
   <main class="pt-28 px-4 md:px-8 max-w-6xl mx-auto w-full min-h-[70vh] flex flex-col gap-10">
     {% block content %}{% endblock %}
   </main>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,19 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Contact | Rules Central{% endblock %}
 
+{% block hero_title %}Contact Us{% endblock %}
+{% block hero_subtitle %}Have questions or need support? Our team is here to help. Reach out and we'll respond within 24 hours.{% endblock %}
+
 {% block content %}
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[40vh] py-12 animate-fadeIn">
-  <div class="container mx-auto px-4">
-    <h1 class="text-4xl md:text-5xl font-extrabold mb-4 text-primary-500 text-center animate-fadeIn">
-      Contact Us
-      <span class="block w-16 h-1 bg-accent-purple mx-auto mt-4 rounded-full"></span>
-    </h1>
-    <p class="text-lg md:text-xl text-slate-300 mb-10 text-center max-w-3xl mx-auto animate-fadeIn delay-100">
-      Have questions or need support? Our team is here to help. Reach out and we'll respond within 24 hours.
-    </p>
-  </div>
-</section>
 
 <section class="relative z-10 container mx-auto px-4 mb-20 animate-fadeIn delay-200">
   <div class="flex flex-col lg:flex-row gap-12 items-start justify-center">

--- a/templates/diagram_viewer.html
+++ b/templates/diagram_viewer.html
@@ -1,13 +1,11 @@
 {% extends "base.html" %}
 {% block title %}Diagram Viewer | Rules Central{% endblock %}
 
+{% block hero_title %}Diagram Viewer{% endblock %}
+{% block hero_subtitle %}View, zoom, and interact with your diagrams in a beautiful, immersive interface.{% endblock %}
+
 {% block content %}
-<!-- Hero Section with Animated Background -->
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[60vh] py-12 animate-fadeIn">
-  <h1 class="text-4xl font-extrabold mb-4 text-primary-500 text-center animate-fadeIn">Diagram Viewer</h1>
-  <p class="text-lg text-slate-300 mb-10 text-center max-w-2xl animate-fadeIn delay-100">View, zoom, and interact with your diagrams in a beautiful, immersive interface.</p>
-  <!-- Diagram Card -->
+<!-- Diagram Card -->
   <div class="relative bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-4xl glassmorphism animate-fadeIn delay-200 flex flex-col items-center">
     <!-- Animated Toolbar -->
     {% include 'partials/diagram_toolbar.html' %}
@@ -26,7 +24,6 @@
       </div>
     </div>
   </div>
-</section>
 {% block scripts %}
 {{ super() }}
 <script>

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -1,13 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Documentation | Rules Central{% endblock %}
 
+{% block hero_title %}Documentation{% endblock %}
+{% block hero_subtitle %}Everything you need to know to master Rules Central. Explore guides, API docs, and best practices.{% endblock %}
+
 {% block content %}
-<!-- Hero Section with Animated Background -->
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[40vh] py-12 animate-fadeIn">
-  <h1 class="text-4xl font-extrabold mb-4 text-primary-500 text-center animate-fadeIn">Documentation</h1>
-  <p class="text-lg text-slate-300 mb-10 text-center max-w-2xl animate-fadeIn delay-100">Everything you need to know to master Rules Central. Explore guides, API docs, and best practices.</p>
-</section>
 <div class="relative flex flex-col md:flex-row gap-8 max-w-7xl mx-auto px-4 animate-fadeIn delay-200">
   <!-- Sticky Table of Contents -->
   <aside class="hidden md:block w-64 sticky top-32 self-start animate-fadeIn delay-300">

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -1,12 +1,10 @@
 {% extends "base.html" %}
 {% block title %}FAQ | Rules Central{% endblock %}
 
+{% block hero_title %}Frequently Asked Questions{% endblock %}
+{% block hero_subtitle %}Find answers to common questions about Rules Central.{% endblock %}
+
 {% block content %}
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[40vh] py-12 animate-fadeIn">
-  <h1 class="text-4xl font-extrabold mb-4 text-primary-500 text-center animate-fadeIn">Frequently Asked Questions</h1>
-  <p class="text-lg text-slate-300 mb-10 text-center max-w-2xl animate-fadeIn delay-100">Find answers to common questions about Rules Central.</p>
-</section>
 <div class="flex flex-col items-center justify-center animate-fadeIn delay-200">
   <div class="bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-2xl glassmorphism">
     <div class="space-y-8">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,12 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Settings | Rules Central{% endblock %}
 
+{% block hero_title %}Settings{% endblock %}
+{% block hero_subtitle %}Personalize your Rules Central experience. All changes are saved instantly.{% endblock %}
+
 {% block content %}
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[40vh] py-12 animate-fadeIn">
-  <h1 class="text-4xl font-extrabold mb-4 text-primary-500 text-center animate-fadeIn">Settings</h1>
-  <p class="text-lg text-slate-300 mb-10 text-center max-w-2xl animate-fadeIn delay-100">Personalize your Rules Central experience. All changes are saved instantly.</p>
-</section>
 <div class="flex flex-col items-center justify-center animate-fadeIn delay-200 w-full px-2">
   <form class="w-full max-w-3xl flex flex-col gap-10" method="post" enctype="multipart/form-data" aria-label="Settings form">
     <!-- Profile Section -->

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,12 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Upload | Rules Central{% endblock %}
 
+{% block hero_title %}Upload Diagram{% endblock %}
+{% block hero_subtitle %}Drag & drop your diagram files here, or click to select from your computer.{% endblock %}
+
 {% block content %}
-{% include 'partials/hero_bg.html' %}
-<section class="relative z-10 flex flex-col items-center justify-center min-h-[40vh] py-12 animate-fadeIn">
-  <h1 class="text-4xl font-extrabold mb-4 text-primary-500 text-center animate-fadeIn">Upload Diagram</h1>
-  <p class="text-lg text-slate-300 mb-10 text-center max-w-2xl animate-fadeIn delay-100">Drag & drop your diagram files here, or click to select from your computer.</p>
-</section>
 <div class="flex flex-col items-center justify-center animate-fadeIn delay-200">
   <form id="uploadForm" class="w-full max-w-xl bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-10 glassmorphism flex flex-col items-center gap-8" method="post" enctype="multipart/form-data" aria-label="Upload form">
     <label for="fileInput" class="w-full flex flex-col items-center justify-center border-2 border-dashed border-primary-500 rounded-2xl p-10 cursor-pointer bg-gradient-to-br from-dark-900/80 to-dark-800/80 hover:from-primary-500/10 hover:to-accent-purple/10 transition-all duration-300 animate-fadeIn" tabindex="0" aria-label="Drag and drop files or click to select">


### PR DESCRIPTION
## Summary
- add hero section rendering to `base.html`
- unify page headers by using `hero_title` and `hero_subtitle` blocks
- remove duplicated hero markup from pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c395dd58c83338e0ff8a4be74c735