### PR TITLE
Fix hero section overlap with header

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
 <body class="bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 min-h-screen font-sans text-white">
   {% include 'partials/header.html' %}
   {% if self.hero_title().strip() or self.hero_subtitle().strip() %}
-  <section class="relative flex flex-col items-center justify-center text-center min-h-[40vh] py-12">
+  <section class="relative flex flex-col items-center justify-center text-center min-h-[40vh] py-12 mt-20">
     {% include 'partials/hero_bg.html' %}
     <div class="relative z-10">
       <h1 class="text-4xl font-extrabold mb-4 text-primary-500">

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,7 +60,7 @@
 {% block content %}
 <div class="bg-dark-900 text-white">
     <!-- Enhanced Hero Section -->
-    <section class="relative overflow-hidden min-h-screen flex items-center">
+    <section class="relative overflow-hidden min-h-screen flex items-center mt-20">
         <!-- Animated Background -->
         <div class="absolute inset-0 bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900"></div>
         <div class="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(59,130,246,0.1),transparent)] animate-pulse"></div>


### PR DESCRIPTION
## Summary
- ensure hero sections start below fixed header by adding top margin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3ba6755c8333bfc6a36fbeca7a67