### PR TITLE
Fix body padding for fixed header

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   {% block head %}{% endblock %}
 </head>
-<body class="bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 min-h-screen font-sans text-white">
+<body class="bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 min-h-screen font-sans text-white pt-20">
   {% include 'partials/header.html' %}
   {% if self.hero_title().strip() or self.hero_subtitle().strip() %}
   <section class="relative flex flex-col items-center justify-center text-center min-h-[40vh] py-12">
@@ -25,7 +25,7 @@
     </div>
   </section>
   {% endif %}
-  <main class="pt-28 px-4 md:px-8 max-w-6xl mx-auto w-full min-h-[70vh] flex flex-col gap-10">
+  <main class="pt-8 px-4 md:px-8 max-w-6xl mx-auto w-full min-h-[70vh] flex flex-col gap-10">
     {% block content %}{% endblock %}
   </main>
   {% include 'partials/footer.html' %}


### PR DESCRIPTION
## Summary
- add padding to body so content clears the fixed header
- drop redundant margins in hero sections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c3ba6755c8333bfc6a36fbeca7a67