### PR TITLE
Improve CSS tokens

### DIFF
--- a/static/css/custom-utilities.css
+++ b/static/css/custom-utilities.css
@@ -181,8 +181,8 @@ body {
   transform: scale(0.98);
 }
 
-.u-focus-ring:focus {
-  outline: 2px solid var(--color-primary);
+.u-focus-ring:focus-visible {
+  outline: 2px solid var(--qc-color-focus-ring);
   outline-offset: 2px;
 }
 

--- a/static/css/tokens.css
+++ b/static/css/tokens.css
@@ -37,14 +37,35 @@
   --qc-color-focus-ring: rgba(167, 139, 250, 0.33);
   --qc-color-shadow: rgba(15, 23, 42, 0.5);
 
+  /* ===== Base Tokens ===== */
+  --qc-bg: var(--qc-color-bg);
+  --qc-bg-dark: var(--qc-color-neutral-900);
+  --qc-bg-light: var(--qc-color-neutral-800);
+  --qc-panel: var(--qc-color-surface);
+  --qc-text-main: var(--qc-color-text);
+  --qc-text-light: var(--qc-color-neutral-200);
+  --qc-text-muted: var(--qc-color-text-muted);
+  --qc-border-color: var(--qc-color-border);
+  --qc-border-radius: var(--qc-radius-md);
+  --qc-border-radius-lg: var(--qc-radius-lg);
+  --qc-link: var(--qc-color-link);
+  --qc-link-hover: var(--qc-color-link-hover);
+  --qc-container-max-width: 72rem;
+
   /* ===== Typography ===== */
   --qc-font-family-sans: 'Plus Jakarta Sans', 'Inter', system-ui, sans-serif;
   --qc-font-family-mono: 'Fira Code', ui-monospace, monospace;
   --qc-font-weight-regular: 400;
   --qc-font-weight-medium: 500;
   --qc-font-weight-bold: 600;
+  --qc-font-weight-thin: 100;
+  --qc-font-weight-light: 300;
+  --qc-font-weight-normal: 400;
+  --qc-font-weight-black: 800;
   --qc-line-height-normal: 1.5;
   --qc-line-height-tight: 1.25;
+  --qc-line-height-base: var(--qc-line-height-normal);
+  --qc-line-height-loose: 1.75;
 
   /* ===== Spacing ===== */
   --qc-space-xxs: 0.25rem;
@@ -54,6 +75,12 @@
   --qc-space-lg: 1.5rem;
   --qc-space-xl: 2rem;
   --qc-space-xxl: 3rem;
+  /* Legacy spacing tokens */
+  --space-0: 0;
+  --space-1: var(--qc-space-xxs);
+  --space-2: var(--qc-space-xs);
+  --space-3: var(--qc-space-sm);
+  --space-4: var(--qc-space-md);
 
   /* ===== Border Radius ===== */
   --qc-radius-sm: 0.375rem;
@@ -93,6 +120,16 @@
   --qc-color-link-hover: var(--qc-color-primary-700);
   --qc-color-focus-ring: rgba(124, 58, 237, 0.2);
   --qc-color-shadow: rgba(0, 0, 0, 0.1);
+  --qc-bg: var(--qc-color-bg);
+  --qc-bg-dark: var(--qc-color-neutral-200);
+  --qc-bg-light: var(--qc-color-neutral-50);
+  --qc-panel: var(--qc-color-surface);
+  --qc-text-main: var(--qc-color-text);
+  --qc-text-light: var(--qc-color-neutral-600);
+  --qc-text-muted: var(--qc-color-text-muted);
+  --qc-border-color: var(--qc-color-border);
+  --qc-link: var(--qc-color-link);
+  --qc-link-hover: var(--qc-color-link-hover);
 }
 
 /* ===== Component Tokens ===== */


### PR DESCRIPTION
## Summary
- define missing CSS design tokens
- add spacing aliases for old classes
- update focus ring to use `:focus-visible`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3e8e93c883339b7bf32f7a86e735