### PR TITLE
Fix header blueprint route

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -4,7 +4,7 @@
 >
   <div class="container mx-auto px-4 flex items-center justify-between h-20">
     <!-- Brand -->
-    <a href="{{ url_for('index') }}" class="flex items-center gap-2 group">
+    <a href="{{ url_for('main.index') }}" class="flex items-center gap-2 group">
       <span class="text-3xl font-extrabold text-white tracking-tight font-display">
         Rules <span class="text-transparent bg-clip-text bg-gradient-to-r from-primary-500 to-accent-purple">Central</span>
       </span>


### PR DESCRIPTION
## Summary
- use `main.index` route for site header to avoid BuildError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d1af7968483338ceb98fb928c82dd