### PR TITLE
Update templates for new utility CSS

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -4,7 +4,7 @@
 business rules and logic.{% endblock %} {% block content %}
 <div class="flex flex-col items-center justify-center animate-fadeIn delay-200">
   <div
-    class="bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-2xl glassmorphism flex flex-col items-center"
+    class="u-card u-card--hoverable w-full max-w-2xl flex flex-col items-center"
   >
     <div class="flex gap-6 mb-8">
       <span

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,10 @@
     />
     <link
       rel="stylesheet"
+      href="{{ url_for('static', filename='css/custom-utilities.css') }}"
+    />
+    <link
+      rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
     />
     <script
@@ -36,11 +40,11 @@
     >
       {% include 'partials/hero_bg.html' %}
       <div class="relative z-10">
-        <h1 class="text-4xl font-extrabold mb-4 text-primary-500">
+        <h1 class="u-text-fluid u-text-balance font-extrabold mb-4 text-primary-500">
           {% block hero_title %}{% endblock %}
         </h1>
         {% if self.hero_subtitle().strip() %}
-        <p class="text-lg text-slate-300 max-w-2xl mx-auto">
+        <p class="text-lg text-slate-300 max-w-2xl mx-auto u-text-balance">
           {% block hero_subtitle %}{% endblock %}
         </p>
         {% endif %}
@@ -48,7 +52,7 @@
     </section>
     {% endif %}
     <main
-      class="pt-8 px-4 md:px-8 max-w-6xl xl:max-w-7xl 2xl:max-w-8xl mx-auto w-full min-h-[70vh] flex flex-col gap-10 scroll-mt-24"
+      class="u-container pt-8 px-4 md:px-8 min-h-[70vh] flex flex-col gap-10 scroll-mt-24"
     >
       {% block content %}{% endblock %}
     </main>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -9,7 +9,7 @@ within 24 hours.{% endblock %} {% block content %}
   <div class="flex flex-col lg:flex-row gap-12 items-start justify-center">
     <!-- Contact Form -->
     <div
-      class="w-full lg:w-1/2 bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-8 md:p-10 glassmorphism transform transition-all hover:shadow-primary-500/10"
+      class="w-full lg:w-1/2 u-card u-card--hoverable transform transition-all"
     >
       <h2
         class="text-2xl font-bold mb-6 text-primary-400 flex items-center gap-2"

--- a/templates/diagram_viewer.html
+++ b/templates/diagram_viewer.html
@@ -4,7 +4,7 @@ hero_subtitle %}View, zoom, and interact with your diagrams in a beautiful,
 immersive interface.{% endblock %} {% block content %}
 <!-- Diagram Card -->
 <div
-  class="relative bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-4xl glassmorphism animate-fadeIn delay-200 flex flex-col items-center"
+  class="relative bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-4xl u-glass animate-fadeIn delay-200 flex flex-col items-center"
 >
   <!-- Animated Toolbar -->
   {% include 'partials/diagram_toolbar.html' %}

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -13,7 +13,7 @@ guides, API docs, and best practices.{% endblock %} {% block content %}
   </aside>
   <!-- Main Content Card -->
   <article
-    class="flex-1 bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 glassmorphism prose prose-invert max-w-none animate-fadeIn delay-400"
+    class="flex-1 bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 u-glass prose prose-invert max-w-none animate-fadeIn delay-400"
   >
     <h2 id="getting-started">Getting Started</h2>
     <p>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -4,7 +4,7 @@ hero_subtitle %}Find answers to common questions about Rules Central.{% endblock
 %} {% block content %}
 <div class="flex flex-col items-center justify-center animate-fadeIn delay-200">
   <div
-    class="bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-2xl glassmorphism"
+    class="bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-2xl u-glass"
   >
     <div class="space-y-8">
       <div>

--- a/templates/partials/activity_timeline.html
+++ b/templates/partials/activity_timeline.html
@@ -18,7 +18,7 @@
       {% endif %}
     </div>
     <div
-      class="bg-dark-800/80 rounded-xl shadow-lg px-6 py-4 glassmorphism flex-1"
+      class="bg-dark-800/80 rounded-xl shadow-lg px-6 py-4 u-glass flex-1"
     >
       <div class="font-bold text-slate-100 text-lg mb-1">{{ event.title }}</div>
       <div class="text-slate-400 text-sm mb-1">{{ event.timestamp }}</div>

--- a/templates/partials/animated_code_block.html
+++ b/templates/partials/animated_code_block.html
@@ -1,5 +1,5 @@
 <div
-  class="relative bg-dark-900/80 rounded-2xl shadow-lg p-6 mb-6 glassmorphism animate-fadeIn"
+  class="relative bg-dark-900/80 rounded-2xl shadow-lg p-6 mb-6 u-glass animate-fadeIn"
 >
   <pre
     class="overflow-x-auto text-sm text-slate-200 font-mono leading-relaxed"

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,7 +1,5 @@
 <footer class="bg-dark-900 border-t border-dark-800 py-8 mt-12 shadow-inner">
-  <div
-    class="max-w-6xl mx-auto px-4 flex flex-col md:flex-row items-center justify-between gap-4"
-  >
+  <div class="u-container px-4 flex flex-col md:flex-row items-center justify-between gap-4">
     <div class="flex items-center gap-2 text-slate-400 text-base">
       <span class="font-bold text-white">Rules Central</span>
       <span>&copy; {{ year or 2025 }}</span>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -1,5 +1,5 @@
 <header class="bg-white/90 dark:bg-dark-900/90 backdrop-blur-xl border-b border-gray-200/80 dark:border-slate-800/60 fixed w-full z-50 shadow-sm hover:shadow-md transition-all duration-300">
-    <div class="container mx-auto px-4 sm:px-6">
+    <div class="u-container px-4 sm:px-6">
         <div class="flex items-center justify-between h-16">
             <!-- Logo (Improved hover effect & accessibility) -->
             <a 

--- a/templates/partials/profile_avatar.html
+++ b/templates/partials/profile_avatar.html
@@ -2,7 +2,7 @@
   <img
     src="{{ user.avatar_url or url_for('static', filename='images/favicon.ico') }}"
     alt="{{ user.name }}'s avatar"
-    class="w-20 h-20 rounded-full border-4 border-primary-500 shadow-lg glassmorphism object-cover animate-fadeIn"
+    class="w-20 h-20 rounded-full border-4 border-primary-500 shadow-lg u-glass object-cover animate-fadeIn"
   />
   <span
     class="absolute bottom-2 right-2 w-5 h-5 rounded-full border-2 border-dark-900 bg-gradient-to-br from-green-400 to-emerald-600 shadow animate-pulse"

--- a/templates/partials/skeleton_loader.html
+++ b/templates/partials/skeleton_loader.html
@@ -4,15 +4,15 @@
   role="status"
 >
   <div
-    class="bg-dark-800/80 rounded-2xl shadow-lg h-8 w-1/2 mx-auto mb-2 glassmorphism"
+    class="bg-dark-800/80 rounded-2xl shadow-lg h-8 w-1/2 mx-auto mb-2 u-glass"
   ></div>
   <div
-    class="bg-dark-800/60 rounded-xl shadow h-6 w-3/4 mx-auto mb-2 glassmorphism"
+    class="bg-dark-800/60 rounded-xl shadow h-6 w-3/4 mx-auto mb-2 u-glass"
   ></div>
   <div
-    class="bg-dark-800/40 rounded-lg shadow h-6 w-2/3 mx-auto mb-2 glassmorphism"
+    class="bg-dark-800/40 rounded-lg shadow h-6 w-2/3 mx-auto mb-2 u-glass"
   ></div>
   <div
-    class="bg-gradient-to-r from-primary-500/20 via-accent-purple/20 to-dark-700/20 rounded-xl h-32 w-full mx-auto mb-2 glassmorphism"
+    class="bg-gradient-to-r from-primary-500/20 via-accent-purple/20 to-dark-700/20 rounded-xl h-32 w-full mx-auto mb-2 u-glass"
   ></div>
 </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -13,7 +13,7 @@ endblock %} {% block content %}
   >
     <!-- Profile Section -->
     <div
-      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 glassmorphism flex flex-col gap-6"
+      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 u-glass flex flex-col gap-6"
     >
       <div class="flex items-center gap-6 mb-4">
         <label for="avatar" class="relative group cursor-pointer">
@@ -73,7 +73,7 @@ endblock %} {% block content %}
     </div>
     <!-- Theme, Language, Timezone -->
     <div
-      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 glassmorphism flex flex-col gap-6"
+      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 u-glass flex flex-col gap-6"
     >
       <div class="flex flex-col md:flex-row gap-6">
         <div class="flex-1">
@@ -132,7 +132,7 @@ endblock %} {% block content %}
     </div>
     <!-- Notifications -->
     <div
-      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 glassmorphism flex flex-col gap-6"
+      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 u-glass flex flex-col gap-6"
     >
       <div class="flex flex-col gap-4">
         <label class="flex items-center justify-between cursor-pointer">
@@ -208,7 +208,7 @@ endblock %} {% block content %}
     </div>
     <!-- Security -->
     <div
-      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 glassmorphism flex flex-col gap-6"
+      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 u-glass flex flex-col gap-6"
     >
       <div class="flex flex-col md:flex-row gap-6">
         <div class="flex-1 flex flex-col gap-2">
@@ -271,7 +271,7 @@ endblock %} {% block content %}
     </div>
     <!-- Experimental Features & Accessibility -->
     <div
-      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 glassmorphism flex flex-col gap-6"
+      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 u-glass flex flex-col gap-6"
     >
       <label class="flex items-center justify-between cursor-pointer mb-4">
         <span class="text-lg text-slate-200 font-semibold"
@@ -347,7 +347,7 @@ endblock %} {% block content %}
     </div>
     <!-- Account Actions -->
     <div
-      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 glassmorphism flex flex-col gap-6"
+      class="bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-8 u-glass flex flex-col gap-6"
     >
       <div class="flex flex-col md:flex-row gap-6 items-center">
         <button

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -5,7 +5,7 @@ endblock %} {% block content %}
 <div class="flex flex-col items-center justify-center animate-fadeIn delay-200">
   <form
     id="uploadForm"
-    class="w-full max-w-xl bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-10 glassmorphism flex flex-col items-center gap-8"
+    class="w-full max-w-xl bg-dark-800/80 rounded-3xl shadow-2xl border border-dark-700 p-10 u-glass flex flex-col items-center gap-8"
     method="post"
     enctype="multipart/form-data"
     aria-label="Upload form"


### PR DESCRIPTION
## Summary
- include new utility CSS
- adopt utility classes in header, footer, and main layout
- migrate `glassmorphism` to `u-glass`
- modernize some cards using `u-card`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db5965da08333817cb95c7e3b32ba