### PR TITLE
Apply design tokens in forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,4 +122,5 @@ if __name__ == "__main__":
     try:
         app.run(debug=True, host="127.0.0.1", port=8080)
     except Exception as exc:
-        LOGGER.critical("Flask app failed to start: %s", exc, exc_info=True)        raise
+        LOGGER.critical("Flask app failed to start: %s", exc, exc_info=True)
+        raise

--- a/static/css/custom-utilities.css
+++ b/static/css/custom-utilities.css
@@ -155,6 +155,36 @@ body {
   color: var(--qc-text-high-contrast);
 }
 
+/* Additional text color utilities */
+.u-text-muted {
+  color: var(--qc-text-muted);
+}
+.u-text-heading {
+  color: var(--qc-color-text-heading);
+}
+
+/* Background helpers */
+.u-bg-elevated {
+  background-color: var(--qc-color-bg-elevated);
+}
+
+/* Border utilities */
+.u-border-primary {
+  border-color: var(--qc-border-color);
+}
+
+/* Form element base styles */
+.u-form-input {
+  background-color: var(--qc-input-bg);
+  border: var(--qc-input-border);
+  border-radius: var(--qc-input-radius);
+  padding: var(--qc-input-padding);
+  color: inherit;
+}
+.u-form-input::placeholder {
+  color: var(--qc-text-muted);
+}
+
 /* ========================================================================
    6. Borders & Effects
    ======================================================================== */

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %} {% block title %}Login | Rules Central{% endblock %}
 {% block content %}
-<section class="flex flex-col items-center justify-center min-h-[60vh]">
+<section class="flex flex-col items-center justify-center min-h-[60vh] u-font-sans">
   <div
-    class="bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-md"
+    class="u-bg-elevated rounded-3xl shadow-2xl u-border-primary p-10 w-full max-w-md"
   >
     <h1 class="text-3xl font-bold mb-6 text-primary-500 text-center">
       Sign In
     </h1>
     <form class="space-y-4">
       <div>
-        <label class="block text-slate-400 mb-1" for="email">Email</label>
+        <label class="block u-text-muted mb-1" for="email">Email</label>
         <input
-          class="w-full rounded-lg bg-dark-900 border border-dark-700 px-4 py-2 text-white focus:ring-2 focus:ring-primary-500"
+          class="u-form-input w-full focus:ring-2 focus:ring-primary-500"
           id="email"
           name="email"
           type="email"
@@ -19,9 +19,9 @@
         />
       </div>
       <div>
-        <label class="block text-slate-400 mb-1" for="password">Password</label>
+        <label class="block u-text-muted mb-1" for="password">Password</label>
         <input
-          class="w-full rounded-lg bg-dark-900 border border-dark-700 px-4 py-2 text-white focus:ring-2 focus:ring-primary-500"
+          class="u-form-input w-full focus:ring-2 focus:ring-primary-500"
           id="password"
           name="password"
           type="password"
@@ -35,7 +35,7 @@
         Sign In
       </button>
     </form>
-    <div class="text-center text-slate-400 mt-4">
+    <div class="text-center u-text-muted mt-4">
       Don't have an account?
       <a href="/register" class="text-primary-400 hover:underline">Register</a>
     </div>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -2,7 +2,7 @@
 %} {% block hero_title %}Create Account{% endblock %} {% block hero_subtitle
 %}Join Rules Central and collaborate{% endblock %} {% block content %}
 <div
-  class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg auth-card"
+  class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg auth-card u-font-sans"
 >
   <div class="text-center mb-4 text-primary-400">
     <i aria-hidden="true" class="fas fa-user-plus text-4xl"></i>
@@ -16,13 +16,13 @@
   >
     <div class="mb-4">
       <label
-        class="block text-sm font-semibold mb-2 text-gray-300"
+        class="block text-sm font-semibold mb-2 u-text-muted"
         for="username"
       >
         Username
       </label>
       <input
-        class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="u-form-input w-full focus:outline-none focus:ring-2 focus:ring-primary-500"
         id="username"
         name="username"
         type="text"
@@ -30,11 +30,11 @@
       />
     </div>
     <div class="mb-4">
-      <label class="block text-sm font-semibold mb-2 text-gray-300" for="email">
+      <label class="block text-sm font-semibold mb-2 u-text-muted" for="email">
         Email
       </label>
       <input
-        class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="u-form-input w-full focus:outline-none focus:ring-2 focus:ring-primary-500"
         id="email"
         name="email"
         type="email"
@@ -43,13 +43,13 @@
     </div>
     <div class="mb-4 relative">
       <label
-        class="block text-sm font-semibold mb-2 text-gray-300"
+        class="block text-sm font-semibold mb-2 u-text-muted"
         for="password"
       >
         Password
       </label>
       <input
-        class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="u-form-input w-full focus:outline-none focus:ring-2 focus:ring-primary-500"
         id="password"
         name="password"
         type="password"
@@ -58,20 +58,20 @@
       <button
         type="button"
         id="togglePassword"
-        class="absolute right-3 top-9 text-slate-400 hover:text-white"
+        class="absolute right-3 top-9 u-text-muted hover:text-white"
       >
         <i aria-hidden="true" class="fas fa-eye"></i>
       </button>
     </div>
     <div class="mb-6 relative">
       <label
-        class="block text-sm font-semibold mb-2 text-gray-300"
+        class="block text-sm font-semibold mb-2 u-text-muted"
         for="confirm_password"
       >
         Confirm Password
       </label>
       <input
-        class="w-full px-3 py-2 bg-dark-800/40 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="u-form-input w-full focus:outline-none focus:ring-2 focus:ring-primary-500"
         id="confirm_password"
         name="confirm_password"
         type="password"
@@ -80,7 +80,7 @@
       <button
         type="button"
         id="toggleConfirm"
-        class="absolute right-3 top-9 text-slate-400 hover:text-white"
+        class="absolute right-3 top-9 u-text-muted hover:text-white"
       >
         <i aria-hidden="true" class="fas fa-eye"></i>
       </button>
@@ -90,7 +90,7 @@
         Register
       </button>
     </div>
-    <div class="mt-4 text-center">
+    <div class="mt-4 text-center u-text-muted">
       <a
         href="{{ url_for('auth.login') }}"
         class="text-primary-400 hover:text-primary-300 text-sm"

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
     {% block head %}{% endblock %}
   </head>
   <body
-    class="bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 min-h-screen font-sans text-white selection:bg-primary-500/20 pt-[var(--header-height)]"
+    class="bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 min-h-screen u-font-sans text-white selection:bg-primary-500/20 pt-[var(--header-height)]"
   >
     <a
       href="#main-content"

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -46,7 +46,7 @@ endblock %} {% block content %}
           ></span>
         </label>
         <div class="flex-1 flex flex-col gap-2">
-          <label class="text-slate-400 text-sm font-semibold" for="display_name"
+          <label class="u-text-muted text-sm font-semibold" for="display_name"
             >Display Name</label
           >
           <input
@@ -54,10 +54,10 @@ endblock %} {% block content %}
             id="display_name"
             name="display_name"
             value="{{ user.display_name }}"
-            class="rounded-lg bg-dark-900 border border-dark-700 px-4 py-3 text-white focus:ring-2 focus:ring-primary-500 text-lg"
+            class="u-form-input w-full text-lg focus:ring-2 focus:ring-primary-500"
             required
           />
-          <label class="text-slate-400 text-sm font-semibold mt-2" for="email"
+          <label class="u-text-muted text-sm font-semibold mt-2" for="email"
             >Email</label
           >
           <input
@@ -65,7 +65,7 @@ endblock %} {% block content %}
             id="email"
             name="email"
             value="{{ user.email }}"
-            class="rounded-lg bg-dark-900 border border-dark-700 px-4 py-3 text-white focus:ring-2 focus:ring-primary-500 text-lg"
+            class="u-form-input w-full text-lg focus:ring-2 focus:ring-primary-500"
             required
           />
         </div>
@@ -78,14 +78,14 @@ endblock %} {% block content %}
       <div class="flex flex-col md:flex-row gap-6">
         <div class="flex-1">
           <label
-            class="block text-slate-400 mb-2 text-lg font-semibold"
+            class="block u-text-muted mb-2 text-lg font-semibold"
             for="theme"
             >Theme</label
           >
           <select
             id="theme"
             name="theme"
-            class="w-full rounded-lg bg-dark-900 border border-dark-700 px-4 py-3 text-white focus:ring-2 focus:ring-primary-500 text-lg"
+            class="u-form-input w-full text-lg focus:ring-2 focus:ring-primary-500"
           >
               <option value="system" {% if settings.theme == "system" %}selected{% endif %}>System</option>
               <option value="dark" {% if settings.theme == "dark" %}selected{% endif %}>Dark</option>
@@ -94,14 +94,14 @@ endblock %} {% block content %}
         </div>
         <div class="flex-1">
           <label
-            class="block text-slate-400 mb-2 text-lg font-semibold"
+            class="block u-text-muted mb-2 text-lg font-semibold"
             for="language"
             >Language</label
           >
           <select
             id="language"
             name="language"
-            class="w-full rounded-lg bg-dark-900 border border-dark-700 px-4 py-3 text-white focus:ring-2 focus:ring-primary-500 text-lg"
+            class="u-form-input w-full text-lg focus:ring-2 focus:ring-primary-500"
           >
               <option value="en" {% if settings.language == "en" %}selected{% endif %}>English</option>
               <option value="es" {% if settings.language == "es" %}selected{% endif %}>Español</option>
@@ -112,7 +112,7 @@ endblock %} {% block content %}
         </div>
         <div class="flex-1">
           <label
-            class="block text-slate-400 mb-2 text-lg font-semibold"
+            class="block u-text-muted mb-2 text-lg font-semibold"
             for="timezone"
             >Timezone</label
           >
@@ -212,7 +212,7 @@ endblock %} {% block content %}
     >
       <div class="flex flex-col md:flex-row gap-6">
         <div class="flex-1 flex flex-col gap-2">
-          <label class="text-slate-400 text-sm font-semibold" for="password"
+          <label class="u-text-muted text-sm font-semibold" for="password"
             >Change Password</label
           >
           <input
@@ -220,11 +220,11 @@ endblock %} {% block content %}
             id="password"
             name="password"
             placeholder="New password"
-            class="rounded-lg bg-dark-900 border border-dark-700 px-4 py-3 text-white focus:ring-2 focus:ring-primary-500 text-lg"
+            class="u-form-input w-full text-lg focus:ring-2 focus:ring-primary-500"
           />
         </div>
         <div class="flex-1 flex flex-col gap-2">
-          <label class="text-slate-400 text-sm font-semibold"
+          <label class="u-text-muted text-sm font-semibold"
             >Two-Factor Authentication</label
           >
           <label class="flex items-center gap-3 cursor-pointer">
@@ -251,7 +251,7 @@ endblock %} {% block content %}
         </div>
       </div>
       <div class="mt-4">
-        <div class="text-slate-400 text-sm mb-2 font-semibold">
+        <div class="u-text-muted text-sm mb-2 font-semibold">
           Active Sessions
         </div>
         <div class="flex flex-col gap-2">
@@ -299,14 +299,14 @@ endblock %} {% block content %}
       <div class="flex flex-col md:flex-row gap-6">
         <div class="flex-1">
           <label
-            class="block text-slate-400 mb-2 text-lg font-semibold"
+            class="block u-text-muted mb-2 text-lg font-semibold"
             for="font_size"
             >Font Size</label
           >
           <select
             id="font_size"
             name="font_size"
-            class="w-full rounded-lg bg-dark-900 border border-dark-700 px-4 py-3 text-white focus:ring-2 focus:ring-primary-500 text-lg"
+            class="u-form-input w-full text-lg focus:ring-2 focus:ring-primary-500"
           >
               <option value="normal" {% if settings.font_size == "normal" %}selected{% endif %}>Normal</option>
               <option value="large" {% if settings.font_size == "large" %}selected{% endif %}>Large</option>
@@ -315,14 +315,14 @@ endblock %} {% block content %}
         </div>
         <div class="flex-1">
           <label
-            class="block text-slate-400 mb-2 text-lg font-semibold"
+            class="block u-text-muted mb-2 text-lg font-semibold"
             for="contrast"
             >Contrast</label
           >
           <select
             id="contrast"
             name="contrast"
-            class="w-full rounded-lg bg-dark-900 border border-dark-700 px-4 py-3 text-white focus:ring-2 focus:ring-primary-500 text-lg"
+            class="u-form-input w-full text-lg focus:ring-2 focus:ring-primary-500"
           >
               <option value="normal" {% if settings.contrast == "normal" %}selected{% endif %}>Normal</option>
               <option value="high" {% if settings.contrast == "high" %}selected{% endif %}>High Contrast</option>
@@ -330,14 +330,14 @@ endblock %} {% block content %}
         </div>
         <div class="flex-1">
           <label
-            class="block text-slate-400 mb-2 text-lg font-semibold"
+            class="block u-text-muted mb-2 text-lg font-semibold"
             for="motion"
             >Motion</label
           >
           <select
             id="motion"
             name="motion"
-            class="w-full rounded-lg bg-dark-900 border border-dark-700 px-4 py-3 text-white focus:ring-2 focus:ring-primary-500 text-lg"
+            class="u-form-input w-full text-lg focus:ring-2 focus:ring-primary-500"
           >
               <option value="normal" {% if settings.motion == "normal" %}selected{% endif %}>Normal</option>
               <option value="reduced" {% if settings.motion == "reduced" %}selected{% endif %}>Reduced Motion</option>


### PR DESCRIPTION
## Summary
- add token-based utilities for text, borders, backgrounds and forms
- use the utilities in login, register and settings pages
- ensure base layout uses tokenized font class
- fix stray raise in `app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc7d959608333972c977f43cd8cca