### PR TITLE
Expand FAQ and Help content

### DIFF
--- a/static/js/help_content.js
+++ b/static/js/help_content.js
@@ -289,7 +289,10 @@ window.helpContent = {
         </p>
         <ul class="list-disc pl-5 text-sm text-slate-300 space-y-1">
           <li><strong>What is Rules Central?</strong> A web platform for managing and visualizing business rules.</li>
-          <li><strong>How do I upload diagrams?</strong> Use the <a href="/upload" class="text-primary-400 hover:underline">Upload</a> page to add JSON files.</li>
+          <li><strong>How do I upload diagrams?</strong> Use the <a href="/upload" class="text-primary-400 hover:underline">Upload</a> page to add JSON or Mermaid files.</li>
+          <li><strong>Where are my diagrams stored?</strong> Uploaded diagrams appear in the catalog and can be searched at any time.</li>
+          <li><strong>Can I share diagrams with others?</strong> Open a diagram and copy its share link from the viewer.</li>
+          <li><strong>What if an upload fails?</strong> Ensure your file is valid JSON and under 10&nbsp;MB, then try again.</li>
           <li><strong>Need more help?</strong> Visit the <a href="/full-help" class="text-primary-400 hover:underline">documentation</a> or email <a href="mailto:support@rulescentral.com" class="text-primary-400 hover:underline">support@rulescentral.com</a>.</li>
         </ul>
       </div>
@@ -298,15 +301,18 @@ window.helpContent = {
   default: {
     title: "Help Center",
     content: `
-      <div class="p-4 bg-dark-800 rounded-lg border border-slate-700">
+      <div class="p-4 bg-dark-800 rounded-lg border border-slate-700 space-y-2">
         <p class="text-sm text-slate-300">
-          For comprehensive documentation, please visit our
-          <a href="/full-help" class="text-primary-400 hover:underline">Help Portal</a>.
+          Welcome to Rules Central. Use the sidebar to browse diagrams and manage rules.
         </p>
-        <p class="text-sm mt-2 text-slate-300">
-          Contact support at
-          <a href="mailto:support@rulescentral.com" class="text-primary-400 hover:underline">support@rulescentral.com</a>
-          for additional assistance.
+        <p class="text-sm text-slate-300">
+          Visit the <a href="/full-help" class="text-primary-400 hover:underline">Help Portal</a> for tutorials and examples.
+        </p>
+        <p class="text-sm text-slate-300">
+          See the <a href="/faq" class="text-primary-400 hover:underline">FAQ</a> for answers to common questions.
+        </p>
+        <p class="text-sm text-slate-300">
+          Need assistance? Email <a href="mailto:support@rulescentral.com" class="text-primary-400 hover:underline">support@rulescentral.com</a>.
         </p>
       </div>
     `,

--- a/static/js/help_system_init.js
+++ b/static/js/help_system_init.js
@@ -38,6 +38,15 @@ window.helpContent = window.helpContent || {
                             Email us at <a href="mailto:support@rulescentral.com" class="text-primary-400 hover:underline">support@rulescentral.com</a>
                         </p>
                     </div>
+                    <div class="p-3 bg-green-900/20 rounded-lg">
+                        <h4 class="font-medium flex items-center">
+                            <i class="fas fa-question-circle mr-2 text-green-400"></i>
+                            FAQ
+                        </h4>
+                        <p class="text-sm mt-2 text-gray-300">
+                            Check the <a href="/faq" class="text-primary-400 hover:underline">FAQ page</a> for quick answers.
+                        </p>
+                    </div>
                 </div>
             `,
   },

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -28,11 +28,47 @@ guides, API docs, and best practices.{% endblock %} {% block content %}
     <h2 id="api">API Usage</h2>
     <p>Interact with the Rules Central API using the following endpoints:</p>
     {% include 'partials/docs_code_block.html' %}
+
+    <h2 id="uploading">Uploading Diagrams</h2>
+    <p>Use the Upload page to add new diagrams or rule sets to your catalog.</p>
+    <ol>
+      <li>Open the <a href="/upload" class="text-primary-400 hover:underline">Upload page</a> from the sidebar.</li>
+      <li>Drag &amp; drop JSON or Mermaid files, or click to select files.</li>
+      <li>Monitor the progress indicator for upload status.</li>
+      <li>After completion, diagrams appear in the catalog automatically.</li>
+    </ol>
+
+    <h2 id="catalog">Exploring the Catalog</h2>
+    <p>The catalog lets you browse, search, and filter all available diagrams.</p>
+    <ul>
+      <li>Use the search bar to find diagrams by name or keyword.</li>
+      <li>Apply type and tag filters to narrow results.</li>
+      <li>Click a diagram card to open it in the viewer.</li>
+      <li>Bookmark favorites for quick access later.</li>
+    </ul>
+
     <h2 id="best-practices">Best Practices</h2>
     <ul>
       <li>Keep your rules modular and well-documented.</li>
       <li>Use the search and filter features to quickly find what you need.</li>
       <li>Collaborate with your team using the built-in tools.</li>
+    </ul>
+
+    <h2 id="roles">User Roles &amp; Permissions</h2>
+    <p>Rules Central supports basic role-based access control.</p>
+    <ul>
+      <li><strong>Admins</strong> manage users and system settings.</li>
+      <li><strong>Editors</strong> can upload and modify diagrams.</li>
+      <li><strong>Viewers</strong> explore diagrams without editing rights.</li>
+    </ul>
+
+    <h2 id="troubleshooting">Troubleshooting</h2>
+    <p>If you encounter issues, try these steps before reaching out.</p>
+    <ul>
+      <li>Verify that uploads are valid JSON and under 10&nbsp;MB.</li>
+      <li>Refresh your browser if diagrams fail to display.</li>
+      <li>Check the logs in the Settings menu for error details.</li>
+      <li>Contact <a href="mailto:support@rulescentral.com" class="text-primary-400 hover:underline">support@rulescentral.com</a> for persistent problems.</li>
     </ul>
     <h2 id="faq">FAQ</h2>
     <p>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -31,6 +31,113 @@ hero_subtitle %}Find answers to common questions about Rules Central.{% endblock
       <div>
         <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
           <svg
+            class="w-6 h-6 mr-2 text-primary-500 animate-bounce"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <circle cx="12" cy="12" r="10" stroke-width="2" />
+            <path
+              d="M16 12H8m8 0a4 4 0 11-8 0 4 4 0 018 0zm0 0v4a4 4 0 01-8 0v-4"
+              stroke-width="2"
+              stroke-linecap="round"
+            /></svg
+          >What file types are supported?
+        </h2>
+        <p class="text-slate-300 text-lg">
+          Rules Central accepts <code>.json</code> and <code>.mmd</code> files for upload.
+        </p>
+      </div>
+      <div>
+        <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
+          <svg
+            class="w-6 h-6 mr-2 text-accent-purple animate-pulse"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <rect x="4" y="12" width="16" height="8" rx="4" stroke-width="2" />
+            <rect
+              x="8"
+              y="8"
+              width="8"
+              height="8"
+              rx="4"
+              stroke-width="2"
+            /></svg
+          >How do I view the hierarchy?
+        </h2>
+        <p class="text-slate-300 text-lg">
+          Open a diagram and click the
+          <span class="text-primary-400">Hierarchy</span> button to explore rule relationships.
+        </p>
+      </div>
+      <div>
+        <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
+          <svg
+            class="w-6 h-6 mr-2 text-primary-500 animate-bounce"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <circle cx="12" cy="12" r="10" stroke-width="2" />
+            <path
+              d="M16 12H8m8 0a4 4 0 11-8 0 4 4 0 018 0zm0 0v4a4 4 0 01-8 0v-4"
+              stroke-width="2"
+              stroke-linecap="round"
+            /></svg
+          >Can I export diagrams?
+        </h2>
+        <p class="text-slate-300 text-lg">
+          Yes. Use the Export option in the viewer to download images or raw files.
+        </p>
+      </div>
+      <div>
+        <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
+          <svg
+            class="w-6 h-6 mr-2 text-accent-purple animate-pulse"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <rect x="4" y="12" width="16" height="8" rx="4" stroke-width="2" />
+            <rect
+              x="8"
+              y="8"
+              width="8"
+              height="8"
+              rx="4"
+              stroke-width="2"
+            /></svg
+          >How do I share diagrams?
+        </h2>
+        <p class="text-slate-300 text-lg">
+          Open a diagram and copy its URL or use the Share button to send it to your team.
+        </p>
+      </div>
+      <div>
+        <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
+          <svg
+            class="w-6 h-6 mr-2 text-primary-500 animate-bounce"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <circle cx="12" cy="12" r="10" stroke-width="2" />
+            <path
+              d="M16 12H8m8 0a4 4 0 11-8 0 4 4 0 018 0zm0 0v4a4 4 0 01-8 0v-4"
+              stroke-width="2"
+              stroke-linecap="round"
+            /></svg
+          >Is there an API?
+        </h2>
+        <p class="text-slate-300 text-lg">
+          Yes. Refer to the <a href="/full-help#api" class="text-primary-400 hover:underline">API section</a> of the documentation for available endpoints.
+        </p>
+      </div>
+      <div>
+        <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
+          <svg
             class="w-6 h-6 mr-2 text-accent-purple animate-pulse"
             fill="none"
             stroke="currentColor"

--- a/templates/partials/docs_toc.html
+++ b/templates/partials/docs_toc.html
@@ -5,7 +5,11 @@
   <h3 class="text-lg font-bold text-primary-400 mb-2">On this page</h3>
   <a href="#getting-started" class="toc-link active">Getting Started</a>
   <a href="#api" class="toc-link">API Usage</a>
+  <a href="#uploading" class="toc-link">Uploading Diagrams</a>
+  <a href="#catalog" class="toc-link">Exploring the Catalog</a>
   <a href="#best-practices" class="toc-link">Best Practices</a>
+  <a href="#roles" class="toc-link">User Roles</a>
+  <a href="#troubleshooting" class="toc-link">Troubleshooting</a>
   <a href="#faq" class="toc-link">FAQ</a>
   <style>
     .toc-link {


### PR DESCRIPTION
## Summary
- broaden documentation with sections on uploading diagrams, catalog, roles and troubleshooting
- expand table of contents for new help topics
- add additional FAQ entries
- enrich help content in the JS overlay and fallback scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dce60b618833381e499571a291e0b