### PR TITLE
Add copy buttons and keyboard shortcuts

### DIFF
--- a/static/css/custom-utilities.css
+++ b/static/css/custom-utilities.css
@@ -307,3 +307,8 @@ body {
 .toast.info {
   background: var(--qc-color-info-400);
 }
+
+/* Copy button for code blocks */
+.has-copy-btn{position:relative;}
+.copy-btn{position:absolute;top:0.5rem;right:0.5rem;padding:0.25rem 0.5rem;font-size:0.75rem;background:var(--qc-color-bg-elevated);color:var(--qc-color-text-primary);border:1px solid var(--qc-color-border, #555);border-radius:var(--qc-radius-sm);opacity:0;transition:opacity .2s;}
+.has-copy-btn:hover .copy-btn{opacity:1;}

--- a/static/js/app-utils.js
+++ b/static/js/app-utils.js
@@ -101,6 +101,48 @@
     });
   };
 
+  // Add copy buttons to all code blocks
+  AppUtils.setupCopyButtons = function () {
+    document.querySelectorAll("pre > code").forEach((code) => {
+      const pre = code.parentElement;
+      if (pre.classList.contains("has-copy-btn")) return;
+      pre.classList.add("has-copy-btn");
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "copy-btn";
+      btn.setAttribute("aria-label", "Copy code");
+      btn.innerHTML = '<i class="fas fa-copy"></i>';
+      btn.addEventListener("click", () => {
+        navigator.clipboard
+          .writeText(code.innerText)
+          .then(() => AppUtils.showToast("Copied to clipboard!", "info"))
+          .catch(() => AppUtils.showToast("Failed to copy", "error"));
+      });
+      pre.appendChild(btn);
+    });
+  };
+
+  // Keyboard shortcuts for common actions
+  AppUtils.setupHotkeys = function () {
+    const searchInput = document.getElementById("search-input");
+    const themeToggle = document.getElementById("theme-toggle");
+    const helpButton = document.getElementById("help-button");
+
+    document.addEventListener("keydown", (e) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.key === "/" && searchInput) {
+        e.preventDefault();
+        searchInput.focus();
+      } else if (e.key.toLowerCase() === "t" && themeToggle) {
+        e.preventDefault();
+        themeToggle.click();
+      } else if (e.shiftKey && e.key === "?" && helpButton) {
+        e.preventDefault();
+        helpButton.click();
+      }
+    });
+  };
+
   global.AppUtils = AppUtils;
   if (!global.app) {
     global.app = AppUtils; // backward compatibility

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -41,6 +41,8 @@
     if (window.AppUtils.initAnimations) window.AppUtils.initAnimations();
     if (window.AppUtils.setupBackToTop) window.AppUtils.setupBackToTop();
     if (window.AppUtils.setupSearchInputs) window.AppUtils.setupSearchInputs();
+    if (window.AppUtils.setupCopyButtons) window.AppUtils.setupCopyButtons();
+    if (window.AppUtils.setupHotkeys) window.AppUtils.setupHotkeys();
     const updateProgress = () => {
       const progress = document.getElementById("scroll-progress");
       if (progress) {

--- a/templates/help_system.html
+++ b/templates/help_system.html
@@ -7,6 +7,7 @@
     title="Open help menu"
     class="w-14 h-14 bg-gradient-to-br from-primary-500 to-accent-purple text-white rounded-full border border-white/5 shadow-lg hover:border-white/10 hover:shadow-2xl transition-all duration-300 ease-out flex items-center justify-center group relative overflow-hidden"
     id="help-button"
+    aria-keyshortcuts="Shift+/"
   >
     <div
       class="absolute inset-0 bg-white/5 rounded-full scale-0 group-hover:scale-100 transition-transform duration-500"

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -100,9 +100,10 @@
             <!-- Right Side Controls (More premium, larger, and animated) -->
             <div class="flex items-center space-x-4">
                 <!-- Theme Toggle (with tooltip) -->
-                <button 
-                    id="theme-toggle" 
+                <button
+                    id="theme-toggle"
                     aria-label="Toggle theme"
+                    aria-keyshortcuts="t"
                     class="p-3 rounded-xl text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-primary-500/50 transition-colors relative group bg-white/60 dark:bg-dark-700/60 shadow hover:shadow-lg"
                     data-tippy-content="Toggle dark mode"
                 >

--- a/templates/search.html
+++ b/templates/search.html
@@ -51,6 +51,7 @@
           </svg>
         </div>
         <input id="search-input"
+               aria-keyshortcuts="/"
                name="q"
                x-model="query"
                type="text"


### PR DESCRIPTION
## Summary
- add `.copy-btn` styles
- implement `setupCopyButtons` and `setupHotkeys` helpers
- invoke new helpers from the main app script
- expose hotkeys via `aria-keyshortcuts`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dda4ae7148333b36307fccf7ae077