### PR TITLE
Improve UI polish with page transitions

### DIFF
--- a/static/css/custom-utilities.css
+++ b/static/css/custom-utilities.css
@@ -312,3 +312,13 @@ body {
 .has-copy-btn{position:relative;}
 .copy-btn{position:absolute;top:0.5rem;right:0.5rem;padding:0.25rem 0.5rem;font-size:0.75rem;background:var(--qc-color-bg-elevated);color:var(--qc-color-text-primary);border:1px solid var(--qc-color-border, #555);border-radius:var(--qc-radius-sm);opacity:0;transition:opacity .2s;}
 .has-copy-btn:hover .copy-btn{opacity:1;}
+
+/* Page transition fade effect */
+.page-transition {
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.page-transition-active {
+  opacity: 1;
+}

--- a/static/js/app-utils.js
+++ b/static/js/app-utils.js
@@ -143,6 +143,40 @@
     });
   };
 
+  // Subtle page fade transitions for same-origin links
+  AppUtils.setupPageTransitions = function () {
+    const body = document.body;
+    if (!body) return;
+
+    body.classList.add("page-transition");
+    requestAnimationFrame(() => {
+      body.classList.add("page-transition-active");
+    });
+
+    document.querySelectorAll("a[href]").forEach((link) => {
+      const url = new URL(link.href, location.href);
+      if (url.origin !== location.origin || url.hash) return;
+
+      link.addEventListener("click", (e) => {
+        if (
+          e.defaultPrevented ||
+          link.target === "_blank" ||
+          e.metaKey ||
+          e.ctrlKey ||
+          e.shiftKey ||
+          e.altKey
+        ) {
+          return;
+        }
+        e.preventDefault();
+        body.classList.remove("page-transition-active");
+        setTimeout(() => {
+          location.href = link.href;
+        }, 200);
+      });
+    });
+  };
+
   global.AppUtils = AppUtils;
   if (!global.app) {
     global.app = AppUtils; // backward compatibility

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -43,6 +43,8 @@
     if (window.AppUtils.setupSearchInputs) window.AppUtils.setupSearchInputs();
     if (window.AppUtils.setupCopyButtons) window.AppUtils.setupCopyButtons();
     if (window.AppUtils.setupHotkeys) window.AppUtils.setupHotkeys();
+    if (window.AppUtils.setupPageTransitions)
+      window.AppUtils.setupPageTransitions();
     const updateProgress = () => {
       const progress = document.getElementById("scroll-progress");
       if (progress) {


### PR DESCRIPTION
## Summary
- add subtle page fade transitions in custom utilities
- support navigation fades via AppUtils
- initialize page transitions in main app script

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ecc5e5a1083339475626692052d78