### PR TITLE
Improve header navigation

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -1,11 +1,31 @@
 <header id="site-header" class="fixed inset-x-0 top-0 z-50 border-b border-dark-700 bg-dark-900/90 backdrop-blur" style="--header-height: 4rem;">
   <div class="u-container flex items-center justify-between h-16">
     <a href="{{ url_for('main.index') }}" class="text-lg font-bold text-white hover:text-primary-400">Rules Central</a>
-    <nav class="hidden md:flex gap-6" aria-label="Main navigation">
-      <a href="{{ url_for('routes.catalog') }}" class="nav-link">Catalog</a>
-      <a href="{{ url_for('main.search') }}" class="nav-link">Search</a>
-      <a href="{{ url_for('main.about') }}" class="nav-link">About</a>
-      <a href="{{ url_for('main.contact') }}" class="nav-link">Contact</a>
+    <nav class="hidden md:flex items-center gap-6" aria-label="Main navigation">
+      <a href="{{ url_for('main.index') }}" class="nav-link flex items-center gap-1">
+        <i class="fas fa-home"></i><span>Home</span>
+      </a>
+      <a href="{{ url_for('routes.catalog') }}" class="nav-link flex items-center gap-1">
+        <i class="fas fa-folder"></i><span>Catalog</span>
+      </a>
+      <a href="{{ url_for('upload.upload_file') }}" class="nav-link flex items-center gap-1">
+        <i class="fas fa-upload"></i><span>Upload</span>
+      </a>
+      <a href="{{ url_for('main.search') }}" class="nav-link flex items-center gap-1">
+        <i class="fas fa-search"></i><span>Search</span>
+      </a>
+      <a href="{{ url_for('user_routes.user_settings') }}" class="nav-link flex items-center gap-1">
+        <i class="fas fa-cog"></i><span>Settings</span>
+      </a>
+      <a href="{{ url_for('routes.faq_page') }}" class="nav-link flex items-center gap-1">
+        <i class="fas fa-question-circle"></i><span>FAQ</span>
+      </a>
+      <a href="{{ url_for('main.about') }}" class="nav-link flex items-center gap-1">
+        <i class="fas fa-info-circle"></i><span>About</span>
+      </a>
+      <a href="{{ url_for('main.contact') }}" class="nav-link flex items-center gap-1">
+        <i class="fas fa-envelope"></i><span>Contact</span>
+      </a>
     </nav>
     <div class="flex items-center gap-3">
       <button id="theme-toggle" class="p-2 text-slate-400 hover:text-primary-400 rounded-lg" aria-label="Toggle theme">
@@ -19,7 +39,10 @@
     <ul class="flex flex-col p-4 gap-2">
       <li><a href="{{ url_for('main.index') }}" class="mobile-nav-link">Home</a></li>
       <li><a href="{{ url_for('routes.catalog') }}" class="mobile-nav-link">Catalog</a></li>
+      <li><a href="{{ url_for('upload.upload_file') }}" class="mobile-nav-link">Upload</a></li>
       <li><a href="{{ url_for('main.search') }}" class="mobile-nav-link">Search</a></li>
+      <li><a href="{{ url_for('user_routes.user_settings') }}" class="mobile-nav-link">Settings</a></li>
+      <li><a href="{{ url_for('routes.faq_page') }}" class="mobile-nav-link">FAQ</a></li>
       <li><a href="{{ url_for('main.about') }}" class="mobile-nav-link">About</a></li>
       <li><a href="{{ url_for('main.contact') }}" class="mobile-nav-link">Contact</a></li>
     </ul>


### PR DESCRIPTION
## Summary
- expand navigation links in the header to match the sidebar
- include icons and additional pages for consistency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ed602a22c833399c9631f10b4254b