### PR TITLE
Improve custom CSS tokens

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -39,7 +39,7 @@
     font-family: var(--qc-font-family-sans);
     background-color: var(--qc-bg);
     color: var(--qc-text-main);
-    text-rendering: optimizeLegibility;
+    text-rendering: optimizelegibility;
     -webkit-tap-highlight-color: transparent;
   }
 
@@ -47,12 +47,13 @@
   body {
     min-height: 100vh;
     min-height: 100dvh; /* Modern viewport unit */
-    background: linear-gradient(
-      135deg,
-      var(--qc-bg) 0%,
-      var(--qc-panel) 50%,
-      var(--qc-bg-dark) 100%
-    );
+    background:
+      linear-gradient(
+        135deg,
+        var(--qc-bg) 0%,
+        var(--qc-panel) 50%,
+        var(--qc-bg-dark) 100%
+      );
     background-attachment: fixed; /* For consistent gradient */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -70,6 +71,7 @@
   /* Interactive elements */
   a {
     --qc-link-underline-offset: 0.25em;
+
     text-underline-offset: var(--qc-link-underline-offset);
     transition: color 0.2s ease, text-decoration-color 0.2s ease;
     text-decoration-thickness: 1px;
@@ -102,8 +104,8 @@
 /* ==========================================================================
    Tailwind Plugin Imports
    ========================================================================== */
-@import "@tailwindcss/forms" layer(base);
-@import "@tailwindcss/typography" layer(components);
-@import "@tailwindcss/aspect-ratio" layer(components);
-@import "daisyui" layer(components);
-@import "./styles/header.css";
+@import url("@tailwindcss/forms") layer(base);
+@import url("@tailwindcss/typography") layer(components);
+@import url("@tailwindcss/aspect-ratio") layer(components);
+@import url("daisyui") layer(components);
+@import url("./styles/header.css");

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -1,7 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap");
 
 * {
-    font-family: 'Inter', sans-serif;
+  font-family: Inter, sans-serif;
 }
 
 @layer components {
@@ -14,7 +14,8 @@
   }
 
   .nav-link::after {
-    content: '';
+    content: "";
+
     @apply absolute bottom-0 left-1/2 w-0 h-0.5 bg-indigo-600 dark:bg-indigo-400 transition-all duration-300 transform -translate-x-1/2;
   }
 
@@ -47,23 +48,24 @@
 @layer utilities {
   .glassmorphism {
     backdrop-filter: blur(12px);
-    background: rgba(255, 255, 255, 0.9);
+    background: rgb(255 255 255 / 90%);
   }
 
   .dark .glassmorphism {
-    background: rgba(17, 24, 39, 0.9);
+    background: rgb(17 24 39 / 90%);
   }
 
   .logo-glow {
-    box-shadow: 0 0 20px rgba(99, 102, 241, 0.3);
+    box-shadow: 0 0 20px rgb(99 102 241 / 30%);
   }
 
   .shadow-glow {
-    box-shadow: 0 0 30px rgba(99, 102, 241, 0.4);
+    box-shadow: 0 0 30px rgb(99 102 241 / 40%);
   }
 
   @keyframes float {
-    0%, 100% { transform: translateY(0px); }
+    0%,
+    100% { transform: translateY(0); }
     50% { transform: translateY(-3px); }
   }
 
@@ -72,7 +74,8 @@
   }
 
   @keyframes bounce-subtle {
-    0%, 100% { transform: translateY(0); }
+    0%,
+    100% { transform: translateY(0); }
     50% { transform: translateY(-5px); }
   }
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -272,11 +272,6 @@
     transform: none;
   }}
 /* Styles migrated from templates/index.html */
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
-    
-    * {
-        font-family: 'Inter', sans-serif;
-    }
     
     .glass-effect {
         background: rgba(15, 23, 42, 0.7);

--- a/static/css/tokens.css
+++ b/static/css/tokens.css
@@ -36,6 +36,10 @@
   --qc-color-danger-400: #f87171;
   --qc-color-info-400: #60a5fa;
 
+  /* Aliases for legacy custom properties */
+  --color-primary: var(--qc-color-primary-500);
+  --color-accent: var(--qc-color-secondary-400);
+
   /* Neutral Colors - Base */
   --qc-color-neutral-0: #ffffff;
   --qc-color-neutral-50: #f8fafc;


### PR DESCRIPTION
## Summary
- run stylelint on CSS sources
- alias `--color-primary` and `--color-accent` to existing tokens
- drop font import from `index.css`

## Testing
- `npm run lint:css`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ee1c0e1c4833382b668ecb9e2103b