### PR TITLE
Unify panel and form styling

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -627,3 +627,40 @@
   box-shadow: 0 0 0 2px var(--color-primary);
 }
 
+/* Panel styles for consistent layouts */
+.panel {
+  background-color: var(--qc-card-bg);
+  border: var(--qc-card-border);
+  border-radius: var(--qc-card-radius);
+  box-shadow: var(--qc-card-shadow);
+  padding: var(--qc-card-padding);
+}
+
+.panel--glass {
+  background-color: var(--qc-color-bg-overlay, rgba(255,255,255,0.1));
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: var(--qc-card-border);
+  border-radius: var(--qc-card-radius);
+  box-shadow: var(--qc-card-shadow);
+  padding: var(--qc-card-padding);
+}
+
+/* Unified input styles */
+.input,
+.input-bordered,
+.u-form-input {
+  background-color: var(--qc-input-bg);
+  border: var(--qc-input-border);
+  border-radius: var(--qc-input-radius);
+  padding: var(--qc-input-padding);
+  color: inherit;
+}
+
+.input:focus,
+.input-bordered:focus,
+.u-form-input:focus {
+  outline: none;
+  box-shadow: var(--qc-input-focus-ring);
+  border-color: var(--qc-color-primary-500);
+}

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,9 +1,7 @@
 {% extends "base.html" %} {% block title %}Login | Rules Central{% endblock %}
 {% block content %}
 <section class="flex flex-col items-center justify-center min-h-[60vh] font-sans">
-  <div
-    class="bg-dark-800 border border-dark-700 rounded-3xl shadow-2xl p-10 w-full max-w-md"
-  >
+  <div class="panel panel--glass w-full max-w-md">
     <h1 class="text-3xl font-bold mb-6 text-primary-500 text-center">
       Sign In
     </h1>
@@ -11,7 +9,7 @@
       <div>
         <label class="block text-slate-400 mb-1" for="email">Email</label>
         <input
-          class="input input-bordered w-full focus:ring-2 focus:ring-primary-500"
+          class="u-form-input w-full"
           id="email"
           name="email"
           type="email"
@@ -21,7 +19,7 @@
       <div>
         <label class="block text-slate-400 mb-1" for="password">Password</label>
         <input
-          class="input input-bordered w-full focus:ring-2 focus:ring-primary-500"
+          class="u-form-input w-full"
           id="password"
           name="password"
           type="password"

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -2,7 +2,7 @@
 %} {% block hero_title %}Create Account{% endblock %} {% block hero_subtitle
 %}Join Rules Central and collaborate{% endblock %} {% block content %}
 <div
-  class="max-w-md mx-auto mt-16 panel panel--glass p-8 rounded-xl shadow-lg font-sans"
+  class="max-w-md mx-auto mt-16 panel panel--glass p-8 font-sans"
 >
   <div class="text-center mb-4 text-primary-400">
     <i aria-hidden="true" class="fas fa-user-plus text-4xl"></i>
@@ -22,7 +22,7 @@
         Username
       </label>
       <input
-        class="input input-bordered w-full focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="u-form-input w-full"
         id="username"
         name="username"
         type="text"
@@ -34,7 +34,7 @@
         Email
       </label>
       <input
-        class="input input-bordered w-full focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="u-form-input w-full"
         id="email"
         name="email"
         type="email"
@@ -49,7 +49,7 @@
         Password
       </label>
       <input
-        class="input input-bordered w-full focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="u-form-input w-full"
         id="password"
         name="password"
         type="password"
@@ -71,7 +71,7 @@
         Confirm Password
       </label>
       <input
-        class="input input-bordered w-full focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="u-form-input w-full"
         id="confirm_password"
         name="confirm_password"
         type="password"

--- a/templates/collab/index.html
+++ b/templates/collab/index.html
@@ -4,7 +4,7 @@ hero_subtitle %}Share diagrams and manage your team{% endblock %} {% block
 content %}
 <div class="max-w-6xl mx-auto px-4 py-12">
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-    <div class="panel panel--glass p-6 rounded-xl shadow-lg">
+    <div class="panel panel--glass p-6">
       <div class="flex justify-between items-center mb-4">
         <h2 class="text-xl font-semibold text-white flex items-center">
           <i aria-hidden="true" class="fas fa-diagram-project mr-2 text-primary-400"></i>Shared
@@ -23,7 +23,7 @@ content %}
       </div>
     </div>
 
-    <div class="panel panel--glass p-6 rounded-xl shadow-lg">
+    <div class="panel panel--glass p-6">
       <div class="flex justify-between items-center mb-4">
         <h2 class="text-xl font-semibold text-white flex items-center">
           <i aria-hidden="true" class="fas fa-clock mr-2 text-primary-400"></i>Recent Activity

--- a/templates/collab/team.html
+++ b/templates/collab/team.html
@@ -2,7 +2,7 @@
 endblock %} {% block hero_title %}Team Management{% endblock %} {% block
 hero_subtitle %}Organize members and roles{% endblock %} {% block content %}
 <div class="max-w-6xl mx-auto px-4 py-12">
-  <div class="panel panel--glass rounded-2xl shadow-xl overflow-hidden">
+  <div class="panel panel--glass overflow-hidden">
     <div class="p-6">
       <div class="flex justify-between items-center mb-6">
         <h2 class="text-xl font-semibold text-white flex items-center">

--- a/templates/config.html
+++ b/templates/config.html
@@ -65,7 +65,7 @@
       <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
         <!-- Theme Selection Panel -->
         <div class="lg:col-span-4">
-          <div class="panel panel--glass rounded-2xl shadow-xl transition-all duration-300 ease-out overflow-hidden h-full flex flex-col">
+          <div class="panel panel--glass transition-all duration-300 ease-out overflow-hidden h-full flex flex-col">
             <div class="p-6 border-b border-white/10 bg-gradient-to-r from-purple-900/30 to-blue-900/30">
               <div class="flex items-center justify-between">
                 <h2 class="text-xl font-bold text-white flex items-center">
@@ -175,7 +175,7 @@
 
         <!-- Style Editor Panel -->
         <div class="lg:col-span-8">
-          <div class="panel panel--glass rounded-2xl shadow-xl transition-all duration-300 ease-out overflow-hidden h-full flex flex-col">
+          <div class="panel panel--glass transition-all duration-300 ease-out overflow-hidden h-full flex flex-col">
             <div class="p-6 border-b border-white/10 bg-gradient-to-r from-purple-900/30 to-blue-900/30">
               <div class="flex items-center justify-between flex-wrap gap-4">
                 <h2 class="text-xl font-bold text-white flex items-center">
@@ -378,7 +378,7 @@
                       <i aria-hidden="true" class="fas fa-sync-alt mr-1.5 text-xs"></i> Refresh
                     </button>
                   </div>
-                  <div aria-live="polite" class="panel panel--glass p-3 min-h-[300px] transition-all duration-300 ease-out rounded-lg" id="diagramContainer">
+                  <div aria-live="polite" class="panel panel--glass p-3 min-h-[300px] transition-all duration-300 ease-out" id="diagramContainer">
                     <div class="flex items-center justify-center h-full text-gray-500 text-sm">
                       <i aria-hidden="true" class="fas fa-image mr-2"></i> Select a theme to see preview
                     </div>
@@ -399,7 +399,7 @@
 
     <!-- New Theme Modal -->
     <div aria-hidden="true" aria-modal="true" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 hidden modal-overlay backdrop-blur-sm" id="newThemeModal">
-      <div class="panel panel--glass shadow-xl p-5 w-full max-w-md rounded-xl" id="newThemeModalContent">
+      <div class="panel panel--glass p-5 w-full max-w-md" id="newThemeModalContent">
         <h3 class="text-lg font-semibold mb-3 text-white">Create New Theme</h3>
         <div class="space-y-3">
           <div>
@@ -432,7 +432,7 @@
 
     <!-- Confirm Delete Modal -->
     <div aria-hidden="true" aria-modal="true" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 hidden modal-overlay backdrop-blur-sm" id="confirmDeleteModal">
-      <div class="panel panel--glass shadow-xl p-5 w-full max-w-md rounded-xl" id="confirmDeleteModalContent">
+      <div class="panel panel--glass p-5 w-full max-w-md" id="confirmDeleteModalContent">
         <h3 class="text-lg font-semibold mb-3 text-white">Confirm Delete</h3>
         <p class="mb-3 text-sm text-gray-300">
           Are you sure you want to delete the theme "<span class="font-medium" id="themeToDelete"></span>"?

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -54,7 +54,7 @@ endblock %} {% block content %}
             id="display_name"
             name="display_name"
             value="{{ user.display_name }}"
-            class="input input-bordered w-full text-lg focus:ring-2 focus:ring-primary-500"
+            class="u-form-input w-full text-lg"
             required
           />
           <label class="text-slate-400 text-sm font-semibold mt-2" for="email"
@@ -65,7 +65,7 @@ endblock %} {% block content %}
             id="email"
             name="email"
             value="{{ user.email }}"
-            class="input input-bordered w-full text-lg focus:ring-2 focus:ring-primary-500"
+            class="u-form-input w-full text-lg"
             required
           />
         </div>
@@ -85,7 +85,7 @@ endblock %} {% block content %}
           <select
             id="theme"
             name="theme"
-            class="input input-bordered w-full text-lg focus:ring-2 focus:ring-primary-500"
+            class="u-form-input w-full text-lg"
           >
               <option value="system" {% if settings.theme == "system" %}selected{% endif %}>System</option>
               <option value="dark" {% if settings.theme == "dark" %}selected{% endif %}>Dark</option>
@@ -101,7 +101,7 @@ endblock %} {% block content %}
           <select
             id="language"
             name="language"
-            class="input input-bordered w-full text-lg focus:ring-2 focus:ring-primary-500"
+            class="u-form-input w-full text-lg"
           >
               <option value="en" {% if settings.language == "en" %}selected{% endif %}>English</option>
               <option value="es" {% if settings.language == "es" %}selected{% endif %}>Español</option>
@@ -220,7 +220,7 @@ endblock %} {% block content %}
             id="password"
             name="password"
             placeholder="New password"
-            class="input input-bordered w-full text-lg focus:ring-2 focus:ring-primary-500"
+            class="u-form-input w-full text-lg"
           />
         </div>
         <div class="flex-1 flex flex-col gap-2">
@@ -306,7 +306,7 @@ endblock %} {% block content %}
           <select
             id="font_size"
             name="font_size"
-            class="input input-bordered w-full text-lg focus:ring-2 focus:ring-primary-500"
+            class="u-form-input w-full text-lg"
           >
               <option value="normal" {% if settings.font_size == "normal" %}selected{% endif %}>Normal</option>
               <option value="large" {% if settings.font_size == "large" %}selected{% endif %}>Large</option>
@@ -322,7 +322,7 @@ endblock %} {% block content %}
           <select
             id="contrast"
             name="contrast"
-            class="input input-bordered w-full text-lg focus:ring-2 focus:ring-primary-500"
+            class="u-form-input w-full text-lg"
           >
               <option value="normal" {% if settings.contrast == "normal" %}selected{% endif %}>Normal</option>
               <option value="high" {% if settings.contrast == "high" %}selected{% endif %}>High Contrast</option>
@@ -337,7 +337,7 @@ endblock %} {% block content %}
           <select
             id="motion"
             name="motion"
-            class="input input-bordered w-full text-lg focus:ring-2 focus:ring-primary-500"
+            class="u-form-input w-full text-lg"
           >
               <option value="normal" {% if settings.motion == "normal" %}selected{% endif %}>Normal</option>
               <option value="reduced" {% if settings.motion == "reduced" %}selected{% endif %}>Reduced Motion</option>


### PR DESCRIPTION
## Summary
- add panel and form base styles
- use `u-form-input` and `panel--glass` across auth and settings pages
- drop redundant classes for collaboration and config panels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fafc70dd483339b08e6216a491ff0