### PR TITLE
Improve accessibility in templates

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,7 +1,11 @@
-{% extends "base.html" %} {% block title %}404 Not Found | Rules Central{%
-endblock %} {% block hero_title %}Page Not Found{% endblock %} {% block
-hero_subtitle %}Sorry, the page you’re looking for doesn’t exist or has been
-moved. Let’s get you back on track!{% endblock %} {% block content %}
+{% extends "base.html" %}
+{% block title %}404 Not Found | Rules Central{% endblock %}
+{% block head %}
+  <meta name="robots" content="noindex">
+{% endblock %}
+{% block hero_title %}Page Not Found{% endblock %}
+{% block hero_subtitle %}Sorry, the page you’re looking for doesn’t exist or has been moved. Let’s get you back on track!{% endblock %}
+{% block content %}
 <section
   class="relative z-10 flex flex-col items-center justify-center py-16 animate-fadeIn"
 >

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,7 +1,11 @@
-{% extends "base.html" %} {% block title %}500 Server Error | Rules Central{%
-endblock %} {% block hero_title %}Server Error{% endblock %} {% block
-hero_subtitle %}Oops! Something went wrong on our end. Please try again later or
-contact support if the issue persists.{% endblock %} {% block content %}
+{% extends "base.html" %}
+{% block title %}500 Server Error | Rules Central{% endblock %}
+{% block head %}
+  <meta name="robots" content="noindex">
+{% endblock %}
+{% block hero_title %}Server Error{% endblock %}
+{% block hero_subtitle %}Oops! Something went wrong on our end. Please try again later or contact support if the issue persists.{% endblock %}
+{% block content %}
 <section
   class="relative z-10 flex flex-col items-center justify-center py-16 animate-fadeIn"
 >

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 {% block title %}Not Found{% endblock %}
+{% block head %}
+  <meta name="robots" content="noindex">
+{% endblock %}
 {% block content %}
 <div class="text-center py-20">
   <h1 class="text-6xl font-bold mb-4">404</h1>

--- a/templates/errors/500.html
+++ b/templates/errors/500.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 {% block title %}Server Error{% endblock %}
+{% block head %}
+  <meta name="robots" content="noindex">
+{% endblock %}
 {% block content %}
 <div class="text-center py-20">
   <h1 class="text-6xl font-bold mb-4">500</h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
 </div>
 
 <!-- Mobile Menu Toggle -->
-<button class="md:hidden fixed top-6 right-6 z-50 p-3 rounded-full bg-slate-800/80 backdrop-blur-sm shadow-lg hover:bg-slate-700 transition-all" onclick="toggleMobileMenu()">
+<button class="md:hidden fixed top-6 right-6 z-50 p-3 rounded-full bg-slate-800/80 backdrop-blur-sm shadow-lg hover:bg-slate-700 transition-all" onclick="toggleMobileMenu()" aria-label="Open menu">
   <i class="fas fa-bars text-white text-xl"></i>
 </button>
 
@@ -247,7 +247,7 @@
 <!-- Enhanced Floating Action Button -->
 <div class="fixed bottom-8 right-8 z-50">
   <div class="relative group">
-    <button class="w-14 h-14 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full shadow-2xl hover:shadow-blue-500/25 transition-all duration-300 hover:scale-110 flex items-center justify-center text-white text-xl">
+    <button class="w-14 h-14 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full shadow-2xl hover:shadow-blue-500/25 transition-all duration-300 hover:scale-110 flex items-center justify-center text-white text-xl" aria-label="Open quick actions">
       <i class="fas fa-plus group-hover:rotate-90 transition-transform"></i>
     </button>
     
@@ -285,7 +285,7 @@
           <i class="fas fa-project-diagram text-blue-400 mr-2"></i>
           Rules Central
         </h2>
-        <button onclick="toggleMobileMenu()" class="text-slate-400 hover:text-white p-2">
+        <button onclick="toggleMobileMenu()" class="text-slate-400 hover:text-white p-2" aria-label="Close menu">
           <i class="fas fa-times"></i>
         </button>
       </div>
@@ -316,7 +316,7 @@
       <div class="pt-4 border-t border-slate-700">
         <div class="flex items-center px-4 py-3">
           <div class="flex-shrink-0">
-            <img class="h-10 w-10 rounded-full" src="https://ui-avatars.com/api/?name=User+Name&background=0ea5e9&color=fff" alt="">
+            <img class="h-10 w-10 rounded-full" src="https://ui-avatars.com/api/?name=User+Name&background=0ea5e9&color=fff" alt="User avatar">
           </div>
           <div class="ml-3">
             <p class="text-sm font-medium text-white">User Name</p>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,7 +19,7 @@ endblock %} {% block content %}
         <label for="avatar" class="relative group cursor-pointer">
           <img
             src="{{ user.avatar_url or url_for('static', filename='images/favicon.ico') }}"
-            alt="Avatar"
+            alt="{{ user.display_name }}'s avatar"
             class="w-20 h-20 rounded-full border-4 border-primary-500 shadow-lg object-cover group-hover:scale-105 transition-all"
           />
           <input


### PR DESCRIPTION
## Summary
- add `meta robots=noindex` to error pages
- ensure avatar images have descriptive alt text
- add ARIA labels to dashboard buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6871471cd8e883339d853b38a0845121