### PR TITLE
Unify hero sections via base template

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1,15 +1,14 @@
 {% extends 'base.html' %}
 {% block title %}About{% endblock %}
+{% block hero_title %}Rules&nbsp;Central{% endblock %}
+{% block hero_subtitle %}A modern platform for visualising and managing rule hierarchies.{% endblock %}
 {% block content %}
 <section class="max-w-4xl mx-auto px-4">
-  <!-- Hero -->
-  <header class="text-center">
-    <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-slate-100">Rules&nbsp;Central</h1>
-    <p class="mt-3 text-lg text-slate-400">A modern platform for visualising and managing rule hierarchies.</p>
-    <span class="inline-block mt-4 rounded-full bg-slate-700/50 px-3 py-1 text-sm font-mono text-primary-300">
+  <p class="text-center mt-4">
+    <span class="inline-block rounded-full bg-slate-700/50 px-3 py-1 text-sm font-mono text-primary-300">
       v{{ version|default('1.0.0') }}
     </span>
-  </header>
+  </p>
 
   <!-- Feature grid -->
   <div class="mt-12 grid gap-6 sm:grid-cols-2">

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -2,10 +2,11 @@
 {% from 'macros/components.html' import input, button, alert %}
 
 {% block title %}Sign in{% endblock %}
+{% block hero_title %}Sign In{% endblock %}
+{% block hero_subtitle %}Welcome back{% endblock %}
 
 {% block content %}
   <div class="max-w-sm mx-auto">
-    <h1 class="text-3xl font-semibold mb-8">Welcome back</h1>
 
     {# show any flashed messages #}
     {% with messages = get_flashed_messages(with_categories=true) %}

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% from 'macros/components.html' import input, button %}
 {% block title %}Register{% endblock %}
+{% block hero_title %}Create Account{% endblock %}
+{% block hero_subtitle %}Join Rules Central by creating an account{% endblock %}
 {% block content %}
 <form action="{{ url_for('routes.index') }}" method="post" class="max-w-sm mx-auto space-y-4">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% set show_back_to_top = false %}
 {% block title %}Catalog Viewer – Rules Central{% endblock %}
+{% block hero_title %}Catalog Viewer{% endblock %}
 
 {% block content %}
 <div class="relative min-h-screen bg-gradient-to-br from-dark-950 to-dark-900 text-white overflow-hidden">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% from 'macros/components.html' import card %}
 {% block title %}Dashboard{% endblock %}
+{% block hero_title %}Dashboard{% endblock %}
 {% block content %}
 <h1 class="sr-only">Dashboard</h1>
 <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-6">

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 {% block title %}Not Found{% endblock %}
+{% block hero_title %}404{% endblock %}
+{% block hero_subtitle %}The page you requested was not found.{% endblock %}
 {% block head %}
   <meta name="robots" content="noindex">
 {% endblock %}
 {% block content %}
 <div class="text-center py-20">
-  <h1 class="text-6xl font-bold mb-4">404</h1>
-  <p class="mb-6">The page you requested was not found.</p>
   <a href="{{ url_for('routes.index') }}" class="px-4 py-2 bg-primary-600 text-white rounded">Back home</a>
 </div>
 {% endblock %}

--- a/templates/errors/500.html
+++ b/templates/errors/500.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 {% block title %}Server Error{% endblock %}
+{% block hero_title %}500{% endblock %}
+{% block hero_subtitle %}An unexpected error occurred.{% endblock %}
 {% block head %}
   <meta name="robots" content="noindex">
 {% endblock %}
 {% block content %}
 <div class="text-center py-20">
-  <h1 class="text-6xl font-bold mb-4">500</h1>
-  <p class="mb-6">An unexpected error occurred.</p>
   <a href="{{ url_for('routes.index') }}" class="px-4 py-2 bg-primary-600 text-white rounded">Back home</a>
 </div>
 {% endblock %}

--- a/templates/rule_detail.html
+++ b/templates/rule_detail.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Rule Details{% endblock %}
+{% block hero_title %}Rule Details{% endblock %}
 {% block content %}
 <div class="grid lg:grid-cols-2 gap-6">
   <div class="bg-slate-800 p-4 rounded overflow-auto">

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% block title %}Search{% endblock %}
+{% block hero_title %}Search Rules{% endblock %}
 {% block content %}
 <section class="max-w-5xl mx-auto px-4">
-  <h1 class="text-3xl font-bold text-slate-200 mb-6">Search Rules</h1>
 
   <!-- Search bar -->
   <form action="{{ url_for('routes.search') }}" method="get" class="flex flex-col sm:flex-row gap-3">

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -2,17 +2,10 @@
 {% from 'macros/components.html' import button, alert %}
 {% block title %}Upload Diagram{% endblock %}
 
+{% block hero_title %}Upload&nbsp;a&nbsp;Diagram{% endblock %}
+{% block hero_subtitle %}Drag &amp; drop or browse for a file (<code>.wr</code>, <code>.json</code>, <code>.png</code>) to add it to Rules&nbsp;Central.{% endblock %}
 {% block content %}
 <section class="max-w-4xl mx-auto px-4 py-12">
-  <!-- Hero -->
-  <header class="text-center mb-10">
-    <h1 class="text-3xl sm:text-4xl font-extrabold text-slate-100 tracking-tight">
-      Upload&nbsp;a&nbsp;Diagram
-    </h1>
-    <p class="mt-3 text-slate-400">
-      Drag &amp; drop or browse for a file (<code>.wr</code>, <code>.json</code>, <code>.png</code>) to add it to Rules&nbsp;Central.
-    </p>
-  </header>
 
   <!-- Upload form -->
   <form id="upload-form"


### PR DESCRIPTION
## Summary
- use `base.html` hero blocks across templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68715a8b50808333bbc617a3e96ab9c8