### PR TITLE
Remove inline styles

### DIFF
--- a/static/css/custom-utilities.css
+++ b/static/css/custom-utilities.css
@@ -39,4 +39,19 @@
       transition: none;
     }
   }
+
+  /* Alpine.js cloaking utility */
+  [x-cloak] {
+    display: none !important;
+  }
+
+  /* Header height custom property */
+  #site-header {
+    --header-height: 4rem;
+  }
+
+  /* Floating action button delays */
+  .fab-delay-1 { --i: 1; }
+  .fab-delay-2 { --i: 2; }
+  .fab-delay-3 { --i: 3; }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -101,7 +101,7 @@
     {% endif %}
 
     <!-- Toast Notification -->
-    <div x-show="showToast" x-transition.opacity class="fixed bottom-4 right-4 bg-dark-800 text-white px-4 py-3 rounded shadow-soft" role="status" aria-live="polite" @click="showToast=false" x-text="toastMsg" style="display:none"></div>
+    <div x-show="showToast" x-transition.opacity class="fixed bottom-4 right-4 bg-dark-800 text-white px-4 py-3 rounded shadow-soft" role="status" aria-live="polite" @click="showToast=false" x-text="toastMsg" x-cloak></div>
 
     <!-- Scripts with nonce and defer -->
     <script defer src="{{ url_for('static', filename='js/app-utils.js') }}" 

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -11,7 +11,7 @@
   {'endpoint': 'main.contact', 'icon': 'fas fa-envelope', 'text': 'Contact'}
 ] %}
 
-<header id="site-header" x-data="{openMobile:false}" class="fixed inset-x-0 top-0 z-50 border-b border-dark-700 bg-dark-900/90 backdrop-blur" style="--header-height: 4rem;">
+<header id="site-header" x-data="{openMobile:false}" class="fixed inset-x-0 top-0 z-50 border-b border-dark-700 bg-dark-900/90 backdrop-blur">
   <div class="u-container flex items-center justify-between h-16">
     <a href="{{ url_for('main.index') }}" class="text-lg font-bold text-white hover:text-primary-400">Rules Central</a>
     <nav class="hidden md:flex items-center gap-6" aria-label="Main navigation">
@@ -27,7 +27,7 @@
         <i class="fas fa-bars"></i>
       </button>
     </div>  </div>
-  <nav id="mobile-menu" x-show="openMobile" x-transition class="md:hidden border-t border-dark-700 bg-dark-900" aria-label="Mobile navigation" @click.away="openMobile=false" style="display:none">
+  <nav id="mobile-menu" x-show="openMobile" x-transition class="md:hidden border-t border-dark-700 bg-dark-900" aria-label="Mobile navigation" @click.away="openMobile=false" x-cloak>
     <ul class="flex flex-col p-4 gap-2">
       {{ render_nav_links(nav_items, is_mobile=true) }}
     </ul>

--- a/templates/partials/hierarchy_viewer_body.html
+++ b/templates/partials/hierarchy_viewer_body.html
@@ -215,24 +215,21 @@ Viewer Body (no
         class="flex flex-col items-end gap-2 opacity-0 translate-y-2 transition-all pointer-events-none"
       >
         <button
-          class="fab-btn floating-action-btn rounded-full bg-amber-500 text-dark-900 w-14 h-14 shadow-lg"
-          style="--i: 1"
+          class="fab-btn floating-action-btn rounded-full bg-amber-500 text-dark-900 w-14 h-14 shadow-lg fab-delay-1"
           aria-label="Export PNG"
           title="Export as PNG"
         >
           <i aria-hidden="true" class="fa-solid fa-file-image text-xl"></i>
         </button>
         <button
-          class="fab-btn floating-action-btn rounded-full bg-emerald-500 text-dark-900 w-14 h-14 shadow-lg"
-          style="--i: 2"
+          class="fab-btn floating-action-btn rounded-full bg-emerald-500 text-dark-900 w-14 h-14 shadow-lg fab-delay-2"
           aria-label="Export PDF"
           title="Export as PDF"
         >
           <i aria-hidden="true" class="fa-solid fa-file-pdf text-xl"></i>
         </button>
         <button
-          class="fab-btn floating-action-btn rounded-full bg-sky-500 text-dark-900 w-14 h-14 shadow-lg"
-          style="--i: 3"
+          class="fab-btn floating-action-btn rounded-full bg-sky-500 text-dark-900 w-14 h-14 shadow-lg fab-delay-3"
           aria-label="Collapse All"
           title="Collapse all nodes"
         >


### PR DESCRIPTION
## Summary
- clean up inline styles in templates
- hide elements using `x-cloak`
- add utilities for header height and floating action button delays

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68715d49ba1c833389b829a0d1f7db19