### PR TITLE
Enhance navigation header

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -11,17 +11,30 @@
   {'endpoint': 'main.contact', 'icon': 'fas fa-envelope', 'text': 'Contact'}
 ] %}
 
-<header id="site-header" x-data="{openMobile:false}" class="fixed inset-x-0 top-0 z-50 border-b border-dark-700 bg-dark-900/90 backdrop-blur">
-  <div class="u-container flex items-center justify-between h-16">
-    <a href="{{ url_for('main.index') }}" class="text-lg font-bold text-white hover:text-primary-400">Rules Central</a>
+<header id="site-header" x-data="{openMobile:false, dark: theme === 'dark'}"
+        class="fixed inset-x-0 top-0 z-50 bg-dark-900/80 text-gray-100 px-6 py-4 flex items-center justify-between backdrop-blur-md transition-all duration-300"
+        x-bind:class="{ 'shadow-md': isScrolled }">
+  <div class="u-container flex items-center justify-between h-8 md:h-12">
+    <a href="{{ url_for('main.index') }}" class="font-semibold text-xl hover:text-primary-300 transition-colors">Rules Central</a>
     <nav class="hidden md:flex items-center gap-6" aria-label="Main navigation">
       <ul class="flex items-center gap-6">
         {{ render_nav_links(nav_items) }}
       </ul>
     </nav>
     <div class="flex items-center gap-3">
-      <button id="theme-toggle" @click="theme = theme==='dark' ? 'light' : 'dark'; showToast=true; toastMsg = theme==='dark' ? 'Dark mode' : 'Light mode'" :aria-pressed="theme==='dark'" class="p-2 text-slate-400 hover:text-primary-400 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500" aria-label="Toggle theme">
-        <i :class="theme==='dark' ? 'fas fa-sun' : 'fas fa-moon'"></i>
+      <button id="theme-toggle"
+              @click="theme = theme === 'dark' ? 'light' : 'dark'; dark = theme === 'dark'; showToast = true; toastMsg = theme === 'dark' ? 'Switched to dark mode' : 'Switched to light mode'"
+              @keydown.enter="theme = theme === 'dark' ? 'light' : 'dark'; dark = theme === 'dark'"
+              @keydown.space="theme = theme === 'dark' ? 'light' : 'dark'; dark = theme === 'dark'"
+              :aria-pressed="dark"
+              class="p-2 rounded hover:bg-primary-700 focus:ring-2 focus:ring-primary-400 transition-all duration-200 hover:scale-110"
+              aria-label="Toggle dark/light theme">
+        <svg x-show="!dark" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8-9h1M3 12H2m14.31 6.31l.71.71m-11.31 0l-.71-.71m0-11.31l.71-.71m11.31 0l-.71.71M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+        </svg>
+        <svg x-show="dark" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 rotate-45" x-transition:enter-end="opacity-100 rotate-0" x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100 rotate-0" x-transition:leave-end="opacity-0 rotate-45">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+        </svg>
       </button>
       <button id="mobile-menu-btn" @click="openMobile = !openMobile" :aria-expanded="openMobile" class="md:hidden p-2 text-slate-400 hover:text-primary-400 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500" aria-label="Open navigation">
         <i class="fas fa-bars"></i>


### PR DESCRIPTION
## Summary
- modernize header navigation
- add animated dark/light theme toggle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68719dc3b4248333b3bc0f4579d062a6