### PR TITLE
Improve macros for better control defaults

### DIFF
--- a/templates/macros/components.html
+++ b/templates/macros/components.html
@@ -1,15 +1,17 @@
-{% macro button(text, variant='primary', type='button') -%}
+{% macro button(text, variant='primary', type='submit') -%}
 {% set classes = {
 'primary':'bg-primary-600 hover:bg-primary-500 text-white',
 'secondary':'bg-slate-700 hover:bg-slate-600 text-white',
 'danger':'bg-red-600 hover:bg-red-500 text-white'
 } %}
-<button type="{{ type }}" class="px-4 py-2 rounded {{ classes[variant] }}">{{ text }}</button>
+<button type="{{ type }}" aria-label="{{ text }}" class="px-4 py-2 rounded {{ classes[variant] }} focus:outline-none focus:ring-2 focus:ring-primary-500">
+  {{ text }}
+</button>
 {%- endmacro %}
 
 {% macro input(name, type='text', placeholder='') -%}
-<input name="{{ name }}" type="{{ type }}" placeholder="{{ placeholder }}"
-  class="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded focus:ring-primary-500">
+<input id="{{ name }}" name="{{ name }}" type="{{ type }}" placeholder="{{ placeholder }}" aria-label="{{ placeholder }}"
+  class="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded focus:ring-primary-500 focus:outline-none">
 {%- endmacro %}
 
 {% macro card(header='', body='') -%}


### PR DESCRIPTION
## Summary
- enhance button and input macros with better accessibility
- default buttons to `type=submit`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6871b842f6108333bde8ef38bbd89db0