### PR TITLE
Improve layout cohesion

### DIFF
--- a/static/css/header.css
+++ b/static/css/header.css
@@ -2,9 +2,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap");
 
 @layer components {
-  .nav-header {
-    @apply sticky top-0 z-50 px-6 py-4 bg-bg-overlay/5 backdrop-blur-2xl border-b border-white/10 lg:hidden;
-  }
 
   .nav-link {
     @apply relative px-4 py-2 text-white/70 hover:text-primary-gradientStart transition-all duration-200 rounded-lg hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-primary-600/50 focus:ring-offset-2 focus:ring-offset-background-darkStart;
@@ -36,25 +33,6 @@
     @apply text-primary-gradientStart bg-white/10;
   }
 
-  .sidebar {
-    @apply fixed left-0 top-0 h-screen w-64 bg-black/30 backdrop-blur-2xl border-r border-white/10 z-[100] transform -translate-x-full transition-transform duration-300 lg:relative lg:translate-x-0;
-  }
-
-  .sidebar.open {
-    @apply translate-x-0;
-  }
-
-  .sidebar-link {
-    @apply flex items-center gap-3 px-4 py-3 rounded-xl text-white hover:bg-white/10 hover:text-primary-gradientStart transition-colors;
-  }
-
-  .sidebar-link.active {
-    @apply bg-white/10 text-primary-gradientStart;
-  }
-
-  .main-content {
-    @apply transition-margin duration-300 lg:ml-64;
-  }
 
   .btn {
     @apply px-4 py-2 rounded-md font-medium transition-all duration-300;

--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -1,4 +1,0 @@
-const sidebar = document.getElementById('sidebar');
-document.querySelectorAll('[data-sidebar-toggle]').forEach(btn => {
-  btn.addEventListener('click', () => sidebar.classList.toggle('hidden'));
-});

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -14,54 +14,7 @@
 {% endblock %}
 
 {% block content %}
-  <!-- Navigation Header -->
-  <div class="nav-header" x-data="{ sidebarOpen: false }">
-    <div class="flex items-center justify-between">
-      <h1 class="text-xl font-bold gradient-text">Rules Central</h1>
-      <button 
-        class="text-white p-2" 
-        x-on:click="sidebarOpen = !sidebarOpen" 
-        aria-label="Toggle sidebar"
-      >
-        <i class="fas fa-bars text-xl"></i>
-      </button>
-    </div>
-  </div>
-
-  <!-- Sidebar -->
-  <div 
-    class="sidebar" 
-    id="sidebar" 
-    x-bind:class="{ 'open': sidebarOpen }" 
-    x-on:click.away="sidebarOpen = false"
-  >
-    <div class="p-6">
-      <h1 class="text-2xl font-bold gradient-text mb-8">Rules Central</h1>
-      <nav class="space-y-4">
-        {% set nav_items = [
-          {"icon": "fa-chart-line", "label": "Dashboard", "endpoint": "routes.index"},
-          {"icon": "fa-file-alt", "label": "Rules", "endpoint": "routes.rules", "active": true},
-          {"icon": "fa-chart-pie", "label": "Analytics", "endpoint": "routes.analytics"},
-          {"icon": "fa-users", "label": "Users", "endpoint": "routes.users"},
-          {"icon": "fa-cog", "label": "Settings", "endpoint": "user_routes.user_settings"}
-        ] %}
-        {% for item in nav_items %}
-          <a 
-            href="{{ url_for(item.endpoint) }}" 
-            class="sidebar-link" 
-            :class="{ 'active': {{ 'true' if item.active else 'false' }} }"
-            aria-current="{{ 'page' if item.active else 'false' }}"
-          >
-            <i class="fas {{ item.icon }}"></i>
-            <span>{{ item.label }}</span>
-          </a>
-        {% endfor %}
-      </nav>
-    </div>
-  </div>
-
-  <!-- Main Content -->
-  <div class="main-content px-6 py-12">
+  <div class="px-6 py-12 space-y-12">
     <section class="mb-12">
       <!-- Search & Filters -->
       <div class="card--glass glassmorphism card-hover p-6 rounded-2xl">

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,54 +19,7 @@
 {% endblock %}
 
 {% block content %}
-  <!-- Navigation Header -->
-  <div class="nav-header" x-data="{ sidebarOpen: false }">
-    <div class="flex items-center justify-between">
-      <h1 class="text-xl font-bold gradient-text">Rules Central</h1>
-      <button 
-        class="text-white p-2" 
-        x-on:click="sidebarOpen = !sidebarOpen" 
-        aria-label="Toggle sidebar"
-      >
-        <i class="fas fa-bars text-xl"></i>
-      </button>
-    </div>
-  </div>
-
-  <!-- Sidebar -->
-  <div 
-    class="sidebar" 
-    id="sidebar" 
-    x-bind:class="{ 'open': sidebarOpen }" 
-    x-on:click.away="sidebarOpen = false"
-  >
-    <div class="p-6">
-      <h1 class="text-2xl font-bold gradient-text mb-8">Rules Central</h1>
-      <nav class="space-y-4">
-        {% set nav_items = [
-          {"icon": "fa-chart-line", "label": "Dashboard", "endpoint": "routes.index", "active": true},
-          {"icon": "fa-file-alt", "label": "Rules", "endpoint": "routes.rules"},
-          {"icon": "fa-chart-pie", "label": "Analytics", "endpoint": "routes.analytics"},
-          {"icon": "fa-users", "label": "Users", "endpoint": "routes.users"},
-          {"icon": "fa-cog", "label": "Settings", "endpoint": "user_routes.user_settings"}
-        ] %}
-        {% for item in nav_items %}
-          <a 
-            href="{{ url_for(item.endpoint) }}" 
-            class="sidebar-link" 
-            :class="{ 'active': {{ 'true' if item.active else 'false' }} }"
-            aria-current="{{ 'page' if item.active else 'false' }}"
-          >
-            <i class="fas {{ item.icon }}"></i>
-            <span>{{ item.label }}</span>
-          </a>
-        {% endfor %}
-      </nav>
-    </div>
-  </div>
-
-  <!-- Main Content -->
-  <div class="main-content px-6 py-12">
+  <div class="px-6 py-12 space-y-12">
     <!-- Stats Section -->
     <section class="mb-12" role="region" aria-labelledby="stats-heading">
       <h2 class="sr-only" id="stats-heading">Dashboard Statistics</h2>


### PR DESCRIPTION
## Summary
- remove page-specific sidebar navigation from `index.html` and `catalog.html`
- drop matching CSS styles and unused `sidebar.js`

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687275a362d4833387ddfff29bb5a637