### PR TITLE
Fix macros for consistent styling

### DIFF
--- a/templates/macros/components.html
+++ b/templates/macros/components.html
@@ -1,61 +1,34 @@
-{% extends 'base.html' %}
-{% from 'macros/components.html' import input, button, alert %}
+{% macro button(text, variant='primary', type='submit', classes='') -%}
+  {%- set variants = {'primary':'btn btn-primary',
+                      'secondary':'btn btn-secondary',
+                      'danger':'btn btn-danger'} -%}
+  <button type="{{ type }}" aria-label="{{ text }}" class="{{ variants.get(variant, 'btn') }} {{ classes }}">
+    {{ text }}
+  </button>
+{%- endmacro %}
 
-{% block title %}Sign In | Rules Central{% endblock %}
+{% macro input(name, type='text', placeholder='', value='', classes='input focus-ring') -%}
+  <input id="{{ name }}" name="{{ name }}" type="{{ type }}" value="{{ value }}" placeholder="{{ placeholder }}" aria-label="{{ placeholder }}" class="{{ classes }}">
+{%- endmacro %}
 
-{% block hero_title %}
-  <h1 class="text-4xl md:text-5xl font-bold text-text tracking-tight text-balance">Sign In</h1>
-{% endblock %}
+{% macro card(header='', body='', classes='card card--glass p-4 rounded-xl') -%}
+  <div class="{{ classes }}">
+    {%- if header %}<h3 class="text-lg font-semibold mb-2">{{ header }}</h3>{% endif %}
+    {{ body }}
+  </div>
+{%- endmacro %}
 
-{% block hero_subtitle %}
-  <p class="mt-4 text-lg md:text-xl text-text-secondary max-w-2xl mx-auto text-pretty">Welcome back to Rules Central</p>
-{% endblock %}
+{% macro alert(message, variant='info', classes='') -%}
+  {%- set colors = {
+      'info':'bg-blue-600',
+      'success':'bg-emerald-600',
+      'warning':'bg-yellow-600',
+      'error':'bg-red-600'
+  } -%}
+  <div role="alert" class="p-3 text-white rounded {{ colors.get(variant, 'bg-blue-600') }} {{ classes }}">{{ message }}</div>
+{%- endmacro %}
 
-{% block content %}
-  <section class="u-section py-8">
-    <div class="max-w-sm mx-auto card card--glass p-8">
-      {# Flashed Messages #}
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          <div class="space-y-4 mb-6" role="alert">
-            {% for category, msg in messages %}
-              {{ alert(msg, variant=category if category else 'info') }}
-            {% endfor %}
-          </div>
-        {% endif %}
-      {% endwith %}
+{% macro skeleton(width='w-full', height='h-4', classes='') -%}
+  <div class="animate-pulse bg-slate-700 rounded {{ width }} {{ height }} {{ classes }}"></div>
+{%- endmacro %}
 
-      {# Sign-in Form #}
-      <form method="post" action="{{ url_for('auth.login') }}" class="space-y-6" x-data="{ showPassword: false }">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-
-        {{ input('email', 'email', 'Email address') }}
-
-        <div class="relative">
-          {{ input('password', 'password' if not showPassword else 'text', 'Password') }}
-          <button 
-            type="button" 
-            x-on:click="showPassword = !showPassword" 
-            class="absolute inset-y-0 right-0 flex items-center px-3 text-text-secondary hover:text-primary-500 focus-ring rounded-r-md"
-            aria-label="Toggle password visibility"
-          >
-            <i x-show="!showPassword" class="fas fa-eye"></i>
-            <i x-show="showPassword" class="fas fa-eye-slash" x-cloak></i>
-          </button>
-        </div>
-
-        {{ button('Sign In', variant='primary', type='submit') }}
-
-        <p class="mt-6 text-center text-sm text-text-secondary">
-          No account yet?
-          <a href="{{ url_for('auth.register') }}" class="text-primary-500 hover:underline focus-ring">Create one</a>
-        </p>
-      </form>
-    </div>
-  </section>
-{% endblock %}
-
-{% block scripts %}
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-{% endblock %}


### PR DESCRIPTION
## Summary
- restore `templates/macros/components.html` macros
- macros now output standard button, input, card, alert and skeleton markup with optional classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68727b74c3c08333bb0095fb29453e4c