### PR TITLE
Refine secondary templates to match dashboard look

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -9,7 +9,7 @@
 <section
   class="relative z-10 flex flex-col items-center justify-center py-16 animate-fadeIn"
 >
-  <div class="flex flex-col items-center">
+  <div class="card--glass glassmorphism card-hover p-8 rounded-2xl flex flex-col items-center">
     <svg
       class="w-40 h-40 mb-8 animate-bounce-slow"
       fill="none"

--- a/templates/500.html
+++ b/templates/500.html
@@ -9,7 +9,7 @@
 <section
   class="relative z-10 flex flex-col items-center justify-center py-16 animate-fadeIn"
 >
-  <div class="flex flex-col items-center">
+  <div class="card--glass glassmorphism card-hover p-8 rounded-2xl flex flex-col items-center">
     <svg class="w-40 h-40 mb-8 animate-pulse" fill="none" viewBox="0 0 200 200">
       <ellipse
         cx="100"

--- a/templates/about.html
+++ b/templates/about.html
@@ -3,7 +3,7 @@
 {% block hero_title %}Rules&nbsp;Central{% endblock %}
 {% block hero_subtitle %}A modern platform for visualising and managing rule hierarchies.{% endblock %}
 {% block content %}
-<section class="max-w-4xl mx-auto px-4">
+<section class="u-section py-12">
   <p class="text-center mt-4">
     <span class="inline-block rounded-full bg-slate-700/50 px-3 py-1 text-sm font-mono text-primary-300">
       v{{ version|default('1.0.0') }}
@@ -12,7 +12,7 @@
 
   <!-- Feature grid -->
   <div class="mt-12 grid gap-6 sm:grid-cols-2">
-    <article class="bg-slate-800/40 backdrop-blur rounded-lg p-6">
+    <article class="card--glass glassmorphism card-hover p-6 rounded-2xl">
       <h2 class="text-xl font-semibold mb-2 text-primary-300">Built with Flask</h2>
       <p class="text-sm text-slate-400">
         Lightweight Python backend powering a fast REST&nbsp;API and server‑side rendering.
@@ -22,7 +22,7 @@
       </a>
     </article>
 
-    <article class="bg-slate-800/40 backdrop-blur rounded-lg p-6">
+    <article class="card--glass glassmorphism card-hover p-6 rounded-2xl">
       <h2 class="text-xl font-semibold mb-2 text-primary-300">Styled by Tailwind&nbsp;CSS</h2>
       <p class="text-sm text-slate-400">
         Utility‑first classes for rapid prototyping and responsive, theme‑aware design.
@@ -32,7 +32,7 @@
       </a>
     </article>
 
-    <article class="bg-slate-800/40 backdrop-blur rounded-lg p-6">
+    <article class="card--glass glassmorphism card-hover p-6 rounded-2xl">
       <h2 class="text-xl font-semibold mb-2 text-primary-300">Fuse.js Search</h2>
       <p class="text-sm text-slate-400">
         Blazing‑fast fuzzy search for instant rule lookup with typo tolerance.
@@ -42,7 +42,7 @@
       </a>
     </article>
 
-    <article class="bg-slate-800/40 backdrop-blur rounded-lg p-6">
+    <article class="card--glass glassmorphism card-hover p-6 rounded-2xl">
       <h2 class="text-xl font-semibold mb-2 text-primary-300">Open&nbsp;Source</h2>
       <p class="text-sm text-slate-400">
         Licensed under MIT. Community contributions are welcome!

--- a/templates/collab/index.html
+++ b/templates/collab/index.html
@@ -4,7 +4,7 @@ hero_subtitle %}Share diagrams and manage your team{% endblock %} {% block
 content %}
 <div class="u-section py-12">
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-    <div class="panel panel--glass p-6">
+    <div class="card--glass glassmorphism card-hover p-6 rounded-2xl">
       <div class="flex justify-between items-center mb-4">
         <h2 class="text-xl font-semibold text-white flex items-center">
           <i aria-hidden="true" class="fas fa-diagram-project mr-2 text-primary-400"></i>Shared
@@ -23,7 +23,7 @@ content %}
       </div>
     </div>
 
-    <div class="panel panel--glass p-6">
+    <div class="card--glass glassmorphism card-hover p-6 rounded-2xl">
       <div class="flex justify-between items-center mb-4">
         <h2 class="text-xl font-semibold text-white flex items-center">
           <i aria-hidden="true" class="fas fa-clock mr-2 text-primary-400"></i>Recent Activity

--- a/templates/collab/team.html
+++ b/templates/collab/team.html
@@ -2,7 +2,7 @@
 endblock %} {% block hero_title %}Team Management{% endblock %} {% block
 hero_subtitle %}Organize members and roles{% endblock %} {% block content %}
 <div class="u-section py-12">
-  <div class="panel panel--glass overflow-hidden">
+  <div class="card--glass glassmorphism card-hover overflow-hidden rounded-2xl">
     <div class="p-6">
       <div class="flex justify-between items-center mb-6">
         <h2 class="text-xl font-semibold text-white flex items-center">

--- a/templates/config.html
+++ b/templates/config.html
@@ -65,7 +65,7 @@
       <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
         <!-- Theme Selection Panel -->
         <div class="lg:col-span-4">
-          <div class="panel panel--glass transition-all duration-300 ease-out overflow-hidden h-full flex flex-col">
+          <div class="card--glass glassmorphism card-hover transition-all duration-300 ease-out overflow-hidden h-full flex flex-col">
             <div class="p-6 border-b border-white/10 bg-gradient-to-r from-purple-900/30 to-blue-900/30">
               <div class="flex items-center justify-between">
                 <h2 class="text-xl font-bold text-white flex items-center">
@@ -175,7 +175,7 @@
 
         <!-- Style Editor Panel -->
         <div class="lg:col-span-8">
-          <div class="panel panel--glass transition-all duration-300 ease-out overflow-hidden h-full flex flex-col">
+          <div class="card--glass glassmorphism card-hover transition-all duration-300 ease-out overflow-hidden h-full flex flex-col">
             <div class="p-6 border-b border-white/10 bg-gradient-to-r from-purple-900/30 to-blue-900/30">
               <div class="flex items-center justify-between flex-wrap gap-4">
                 <h2 class="text-xl font-bold text-white flex items-center">
@@ -378,7 +378,7 @@
                       <i aria-hidden="true" class="fas fa-sync-alt mr-1.5 text-xs"></i> Refresh
                     </button>
                   </div>
-                  <div aria-live="polite" class="panel panel--glass p-3 min-h-[300px] transition-all duration-300 ease-out" id="diagramContainer">
+                  <div aria-live="polite" class="card--glass glassmorphism card-hover p-3 min-h-[300px] transition-all duration-300 ease-out" id="diagramContainer">
                     <div class="flex items-center justify-center h-full text-gray-500 text-sm">
                       <i aria-hidden="true" class="fas fa-image mr-2"></i> Select a theme to see preview
                     </div>
@@ -399,7 +399,7 @@
 
     <!-- New Theme Modal -->
     <div aria-hidden="true" aria-modal="true" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 hidden modal-overlay backdrop-blur-sm" id="newThemeModal">
-      <div class="panel panel--glass p-5 w-full max-w-md" id="newThemeModalContent">
+      <div class="card--glass glassmorphism card-hover p-5 w-full max-w-md" id="newThemeModalContent">
         <h3 class="text-lg font-semibold mb-3 text-white">Create New Theme</h3>
         <div class="space-y-3">
           <div>
@@ -432,7 +432,7 @@
 
     <!-- Confirm Delete Modal -->
     <div aria-hidden="true" aria-modal="true" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 hidden modal-overlay backdrop-blur-sm" id="confirmDeleteModal">
-      <div class="panel panel--glass p-5 w-full max-w-md" id="confirmDeleteModalContent">
+      <div class="card--glass glassmorphism card-hover p-5 w-full max-w-md" id="confirmDeleteModalContent">
         <h3 class="text-lg font-semibold mb-3 text-white">Confirm Delete</h3>
         <p class="mb-3 text-sm text-gray-300">
           Are you sure you want to delete the theme "<span class="font-medium" id="themeToDelete"></span>"?

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -9,7 +9,7 @@ within 24 hours.{% endblock %} {% block content %}
   <div class="flex flex-col lg:flex-row gap-12 items-start justify-center">
     <!-- Contact Form -->
     <div
-      class="w-full lg:w-1/2 u-card u-card--hoverable transform transition-all"
+      class="w-full lg:w-1/2 card--glass glassmorphism card-hover p-8 rounded-2xl"
     >
       <h2
         class="text-2xl font-bold mb-6 text-primary-400 flex items-center gap-2"
@@ -129,7 +129,7 @@ within 24 hours.{% endblock %} {% block content %}
 
     <!-- Contact Info -->
     <div class="w-full lg:w-1/2 space-y-8">
-      <div class="bg-dark-800 rounded-3xl border border-dark-700 p-8 md:p-10">
+      <div class="card--glass glassmorphism p-8 md:p-10 rounded-2xl">
         <h2
           class="text-2xl font-bold mb-6 text-primary-400 flex items-center gap-2"
         >
@@ -226,7 +226,7 @@ within 24 hours.{% endblock %} {% block content %}
         </div>
       </div>
 
-      <div class="bg-dark-800 rounded-3xl border border-dark-700 p-8 md:p-10">
+      <div class="card--glass glassmorphism p-8 md:p-10 rounded-2xl">
         <h2
           class="text-2xl font-bold mb-6 text-primary-400 flex items-center gap-2"
         >

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,6 +3,7 @@
 {% block title %}Dashboard{% endblock %}
 {% block hero_title %}Dashboard{% endblock %}
 {% block content %}
+<div class="u-section py-12">
 <h1 class="sr-only">Dashboard</h1>
 <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-6">
   {{ card('Rules', '<p class="text-2xl font-bold">' ~ (metrics.rules|default(0)) ~ '</p>') }}
@@ -11,12 +12,13 @@
   {{ card('Errors', '<p class="text-2xl font-bold">' ~ (metrics.errors|default(0)) ~ '</p>') }}
 </div>
 <div class="grid gap-6 lg:grid-cols-2">
-  <div class="bg-slate-800 p-4 rounded">
+  <div class="card--glass glassmorphism p-6 rounded-2xl">
     <canvas id="chart-rules" class="w-full h-64"></canvas>
   </div>
-  <div class="bg-slate-800 p-4 rounded">
+  <div class="card--glass glassmorphism p-6 rounded-2xl">
     <canvas id="chart-uploads" class="w-full h-64"></canvas>
   </div>
+</div>
 </div>
 {% endblock %}
 {% block scripts %}

--- a/templates/diagram_viewer.html
+++ b/templates/diagram_viewer.html
@@ -2,9 +2,10 @@
 endblock %} {% block hero_title %}Diagram Viewer{% endblock %} {% block
 hero_subtitle %}View, zoom, and interact with your diagrams in a beautiful,
 immersive interface.{% endblock %} {% block content %}
+<div class="u-section py-12">
 <!-- Diagram Card -->
 <div
-  class="relative bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-4xl u-glass animate-fadeIn delay-200 flex flex-col items-center"
+  class="relative card--glass glassmorphism p-10 rounded-3xl animate-fadeIn delay-200 flex flex-col items-center"
 >
   <!-- Animated Toolbar -->
   {% include 'partials/diagram_toolbar.html' %}
@@ -30,6 +31,7 @@ immersive interface.{% endblock %} {% block content %}
       </svg>
     </div>
   </div>
+</div>
 </div>
 {% block scripts %} {{ super() }}
 <script>

--- a/templates/rule_detail.html
+++ b/templates/rule_detail.html
@@ -2,11 +2,11 @@
 {% block title %}Rule Details{% endblock %}
 {% block hero_title %}Rule Details{% endblock %}
 {% block content %}
-<div class="grid lg:grid-cols-2 gap-6">
-  <div class="bg-slate-800 p-4 rounded overflow-auto">
+<div class="u-section py-12 grid lg:grid-cols-2 gap-6">
+  <div class="card--glass glassmorphism p-6 rounded-2xl overflow-auto">
     <pre>{{ tree_view|default('') }}</pre>
   </div>
-  <div class="bg-slate-800 p-4 rounded">
+  <div class="card--glass glassmorphism p-6 rounded-2xl">
     <div class="border-b border-slate-700 mb-4 flex">
       <button hx-get="{{ url_for('routes.rule_tab', id=rule.id, tab='info') }}" hx-target="#tab-content" class="px-3 py-2">Info</button>
       <button hx-get="{{ url_for('routes.rule_tab', id=rule.id, tab='history') }}" hx-target="#tab-content" class="px-3 py-2">History</button>

--- a/templates/search.html
+++ b/templates/search.html
@@ -2,7 +2,7 @@
 {% block title %}Search{% endblock %}
 {% block hero_title %}Search Rules{% endblock %}
 {% block content %}
-<section class="max-w-5xl mx-auto px-4">
+<section class="u-section py-12">
 
   <!-- Search bar -->
   <form action="{{ url_for('routes.search') }}" method="get" class="flex flex-col sm:flex-row gap-3">
@@ -38,7 +38,7 @@
 
   <div class="flex mt-8 gap-8">
     <!-- Desktop filters -->
-    <aside class="w-64 shrink-0 hidden lg:block">
+    <aside class="w-64 shrink-0 hidden lg:block card--glass glassmorphism p-4 rounded-2xl">
       <h2 class="text-lg font-semibold mb-3">Filters</h2>
       <ul class="space-y-3">
         <li><label class="flex items-center"><input type="checkbox" name="f1" class="mr-2">Active</label></li>
@@ -51,9 +51,9 @@
       {% if results %}
         <p class="text-sm text-slate-400 mb-3">{{ results|length }} result{{ 's' if results|length != 1 }}</p>
       {% endif %}
-      <ul class="divide-y divide-slate-700 rounded-md overflow-hidden bg-slate-800/40">
+      <ul class="divide-y divide-white/10 rounded-xl overflow-hidden card--glass glassmorphism">
         {% for item in results|default([]) %}
-          <li class="py-4 px-4 hover:bg-slate-800/60 transition group">
+          <li class="py-4 px-4 hover:bg-white/5 transition group">
             <a href="{{ url_for('routes.rule_detail', id=item.id) }}"
                class="text-primary-400 group-hover:text-primary-300 text-lg font-medium">{{ item.name }}</a>
             {% if item.description %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -20,7 +20,7 @@
   >
     <!-- Profile Section -->
     <div
-      class="card--glass p-10"
+      class="card--glass glassmorphism card-hover p-10 rounded-2xl"
       data-aos="fade-up"
       data-aos-delay="100"
     >
@@ -88,7 +88,7 @@
 
     <!-- Theme, Language, Timezone -->
     <div
-      class="card--glass p-10"
+      class="card--glass glassmorphism card-hover p-10 rounded-2xl"
       data-aos="fade-up"
       data-aos-delay="200"
     >
@@ -126,7 +126,7 @@
 
     <!-- Notifications -->
     <div
-      class="card--glass p-10"
+      class="card--glass glassmorphism card-hover p-10 rounded-2xl"
       data-aos="fade-up"
       data-aos-delay="300"
     >
@@ -190,7 +190,7 @@
 
     <!-- Security -->
     <div
-      class="card--glass p-10"
+      class="card--glass glassmorphism card-hover p-10 rounded-2xl"
       data-aos="fade-up"
       data-aos-delay="400"
     >
@@ -245,7 +245,7 @@
 
     <!-- Experimental Features & Accessibility -->
     <div
-      class="card--glass p-10"
+      class="card--glass glassmorphism card-hover p-10 rounded-2xl"
       data-aos="fade-up"
       data-aos-delay="500"
     >
@@ -295,7 +295,7 @@
 
     <!-- Account Actions -->
     <div
-      class="card--glass p-10"
+      class="card--glass glassmorphism card-hover p-10 rounded-2xl"
       data-aos="fade-up"
       data-aos-delay="600"
     >

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -5,8 +5,9 @@
 {% block hero_title %}Upload&nbsp;a&nbsp;Diagram{% endblock %}
 {% block hero_subtitle %}Drag &amp; drop or browse for a file (<code>.wr</code>, <code>.json</code>, <code>.png</code>) to add it to Rules&nbsp;Central.{% endblock %}
 {% block content %}
-<section class="max-w-4xl mx-auto px-4 py-12">
+<section class="u-section py-12">
 
+  <div class="card--glass glassmorphism p-8 rounded-2xl">
   <!-- Upload form -->
   <form id="upload-form"
         action="{{ url_for('routes.upload_file') }}"
@@ -78,6 +79,7 @@
            :style="`width: ${progress}%`"></div>
     </div>
   </form>
+  </div>
 </section>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- apply glassmorphism cards and hover effects across pages
- standardise sections using `u-section` containers
- restyle contact form, search results and dashboard graphs
- polish error pages with floating glass panels
- clean up settings and other utility pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687295ba2ae483339bfbc4e224636b58