### PR TITLE
Add hero subtitles for pages

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,6 +2,7 @@
 {% from 'macros/components.html' import card %}
 {% block title %}Dashboard{% endblock %}
 {% block hero_title %}Dashboard{% endblock %}
+{% block hero_subtitle %}A high level overview of activity and system health.{% endblock %}
 {% block content %}
 <h1 class="sr-only">Dashboard</h1>
 <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-6">

--- a/templates/rule_detail.html
+++ b/templates/rule_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Rule Details{% endblock %}
 {% block hero_title %}Rule Details{% endblock %}
+{% block hero_subtitle %}Detailed view and history of the selected rule.{% endblock %}
 {% block content %}
 <div class="grid lg:grid-cols-2 gap-6">
   <div class="bg-slate-800 p-4 rounded overflow-auto">

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Search{% endblock %}
 {% block hero_title %}Search Rules{% endblock %}
+{% block hero_subtitle %}Quickly find rules using keywords and filters.{% endblock %}
 {% block content %}
 <section class="max-w-5xl mx-auto px-4">
 


### PR DESCRIPTION
## Summary
- enhance Dashboard, Rule Detail, and Search pages with hero subtitles for a consistent aesthetic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68728a910b548333913cbe3a930f65b1