### PR TITLE
Improve template styles

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -25,7 +25,7 @@
       
       <!-- Stats Cards -->
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-12">
-        <div class="bg-dark-850 p-6 rounded-2xl shadow-xl hover:shadow-2xl transition-all duration-300 flex items-center gap-4 hover:-translate-y-1">
+        <div class="card--glass glassmorphism card-hover p-6 rounded-2xl flex items-center gap-4">
           <div class="w-12 h-12 rounded-xl bg-purple-500/10 flex items-center justify-center text-purple-300">
             <i aria-hidden="true" class="fas fa-palette text-xl"></i>
           </div>
@@ -35,7 +35,7 @@
           </div>
         </div>
         
-        <div class="bg-dark-850 p-6 rounded-2xl shadow-xl hover:shadow-2xl transition-all duration-300 flex items-center gap-4 hover:-translate-y-1">
+        <div class="card--glass glassmorphism card-hover p-6 rounded-2xl flex items-center gap-4">
           <div class="w-12 h-12 rounded-xl bg-teal-500/10 flex items-center justify-center text-teal-300">
             <i aria-hidden="true" class="fas fa-layer-group text-xl"></i>
           </div>
@@ -45,7 +45,7 @@
           </div>
         </div>
         
-        <div class="bg-dark-850 p-6 rounded-2xl shadow-xl hover:shadow-2xl transition-all duration-300 flex items-center gap-4 hover:-translate-y-1">
+        <div class="card--glass glassmorphism card-hover p-6 rounded-2xl flex items-center gap-4">
           <div class="w-12 h-12 rounded-xl bg-blue-500/10 flex items-center justify-center text-blue-300">
             <i aria-hidden="true" class="fas fa-sliders-h text-xl"></i>
           </div>

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -7,13 +7,13 @@ guides, API docs, and best practices.{% endblock %} {% block content %}
 >
   <!-- Sticky Table of Contents -->
   <aside
-    class="hidden md:block w-64 sticky top-32 self-start animate-fadeIn delay-300"
+    class="hidden md:block w-64 sticky top-32 self-start animate-fadeIn delay-300 card--glass glassmorphism card-hover p-6"
   >
     {% include 'partials/docs_toc.html' %}
   </aside>
   <!-- Main Content Card -->
   <article
-    class="flex-1 bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 u-glass prose prose-invert max-w-none animate-fadeIn delay-400"
+    class="flex-1 card--glass glassmorphism card-hover p-10 rounded-3xl prose prose-invert max-w-none animate-fadeIn delay-400"
   >
     <h2 id="getting-started">Getting Started</h2>
     <p>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -4,7 +4,7 @@ hero_subtitle %}Find answers to common questions about Rules Central.{% endblock
 %} {% block content %}
 <div class="flex flex-col items-center justify-center animate-fadeIn delay-200">
   <div
-    class="bg-dark-800 rounded-3xl shadow-2xl border border-dark-700 p-10 w-full max-w-2xl u-glass"
+    class="card--glass glassmorphism card-hover p-10 rounded-3xl w-full max-w-2xl"
   >
     <div class="space-y-8">
       <div>

--- a/templates/includes/_activity_stats.html
+++ b/templates/includes/_activity_stats.html
@@ -1,6 +1,6 @@
 <div class="u-section py-12 relative z-10">
   <div
-    class="glass-panel rounded-3xl p-10 shadow-2xl animate-on-scroll hover-lift bg-gradient-to-br from-dark-800/80 to-dark-900/90 border border-primary-500/10"
+    class="card--glass glassmorphism card-hover p-10 rounded-3xl animate-on-scroll"
   >
     <h3
       class="text-3xl font-extrabold text-white mb-8 flex items-center gap-4 drop-shadow-lg"

--- a/templates/partials/docs_code_block.html
+++ b/templates/partials/docs_code_block.html
@@ -1,5 +1,5 @@
 <div
-  class="relative bg-dark-900 rounded-2xl shadow-lg border border-dark-700 p-6 animate-fadeIn mb-8"
+  class="relative card--glass glassmorphism card-hover p-6 animate-fadeIn mb-8"
 >
   <div class="flex items-center justify-between mb-2">
     <span class="text-primary-400 font-mono text-base">Example API Call</span>

--- a/templates/partials/docs_toc.html
+++ b/templates/partials/docs_toc.html
@@ -1,6 +1,6 @@
 <nav
   aria-label="Table of contents"
-  class="flex flex-col gap-3 bg-dark-900/80 backdrop-blur rounded-2xl shadow-lg p-6"
+  class="flex flex-col gap-3 card--glass glassmorphism card-hover p-6"
 >
   <h3 class="text-lg font-bold text-primary-400 mb-2">On this page</h3>
   <a href="#getting-started" class="toc-link active">Getting Started</a>


### PR DESCRIPTION
## Summary
- use glassmorphism styles consistently in docs and FAQ pages
- update stats cards and activity stats panel to match index.html design
- ensure doc code blocks and TOC use unified card styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729a040c54833391576ece86127753