### PR TITLE
Improve docs and help

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Upload diagrams, explore rule hierarchies and collaborate with your team all in 
 - **API utility** for testing rules
 - **About** page with version info and documentation links
 - **Clean typography** using custom fonts
-- **Help center** with full documentation
+- **In‑app help overlay** (press `Shift+/`)
 - **Contact page** for sending feedback
 
 ## Requirements
@@ -54,6 +54,7 @@ python app.py
 ```
 Then open [http://127.0.0.1:8080](http://127.0.0.1:8080) in your browser.
 Visit [/about](http://127.0.0.1:8080/about) for version info and links.
+Press `Shift+/` at any time to open the built‑in help overlay.
 
 ## Running Tests
 Run the unit tests with:
@@ -68,6 +69,13 @@ Set the ``CONFIG_PATH`` environment variable to load an alternative
 ```bash
 export CONFIG_PATH=/path/to/config.json
 ```
+
+Additional environment variables:
+
+- `SECRET_KEY` – override the generated secret key
+- `UPLOAD_FOLDER` – directory for uploaded files
+- `DIAGRAMS_FOLDER` – directory for generated diagrams
+- `PORT` – port for `wsgi.py` when run directly
 
 ## Project structure
 - `app.py` – application factory
@@ -90,6 +98,7 @@ The site will be available at http://127.0.0.1:8080.
 ## Documentation
 
 Full usage guides and API references are available at [http://127.0.0.1:8080/full-help](http://127.0.0.1:8080/full-help).
+For quick tips while browsing the site press `Shift+/` to open the help menu.
 
 ## License
 This project is provided as‑is without warranty.

--- a/static/js/help_content.js
+++ b/static/js/help_content.js
@@ -37,7 +37,8 @@ const HelpSystem = {
             "Drag-and-drop JSON files directly onto the upload page",
             "Bookmark frequently used diagrams for quick access",
             "Customize diagram colors in the Theme Manager",
-            "Use Ctrl+F to search within diagram viewers"
+            "Use Ctrl+F to search within diagram viewers",
+            "Press <kbd>Shift</kbd>+<kbd>/</kbd> for contextual help"
           ]
         }
       ]
@@ -57,6 +58,9 @@ const HelpSystem = {
             </p>
             <p class="text-sm text-slate-300">
               See the <a href="/faq" class="text-primary-400 hover:underline">FAQ</a> for answers to common questions.
+            </p>
+            <p class="text-sm text-slate-300">
+              Press <kbd>Shift</kbd> + <kbd>/</kbd> to open this window at any time.
             </p>
             <p class="text-sm text-slate-300">
               Need assistance? Email <a href="mailto:support@rulescentral.com" class="text-primary-400 hover:underline">support@rulescentral.com</a>.

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -72,6 +72,9 @@ guides, API docs, and best practices.{% endblock %} {% block content %}
       <li>Set the <code>CONFIG_PATH</code> environment variable if you need a custom configuration file.</li>
       <li>Contact <a href="mailto:support@rulescentral.com" class="text-primary-400 hover:underline">support@rulescentral.com</a> for persistent problems.</li>
     </ul>
+
+    <h2 id="shortcuts">Keyboard Shortcuts</h2>
+    <p>Press <kbd>Shift</kbd> + <kbd>/</kbd> to open the help overlay from any page.</p>
     <h2 id="faq">FAQ</h2>
     <p>
       See the

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -184,6 +184,43 @@ hero_subtitle %}Find answers to common questions about Rules Central.{% endblock
       <div>
         <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
           <svg
+            class="w-6 h-6 mr-2 text-primary-500 animate-bounce"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <circle cx="12" cy="12" r="10" stroke-width="2" />
+            <path d="M12 8v4" stroke-width="2" stroke-linecap="round" />
+            <path d="M12 16h.01" stroke-width="2" stroke-linecap="round" />
+          </svg>
+          How do I reset my password?
+        </h2>
+        <p class="text-slate-300 text-lg">
+          Click <span class="text-primary-400">Forgot password</span> on the
+          login page and follow the emailed instructions.
+        </p>
+      </div>
+      <div>
+        <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
+          <svg
+            class="w-6 h-6 mr-2 text-accent-purple animate-pulse"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <rect x="4" y="12" width="16" height="8" rx="4" stroke-width="2" />
+            <rect x="8" y="8" width="8" height="8" rx="4" stroke-width="2" />
+          </svg>
+          Is there a keyboard shortcut for help?
+        </h2>
+        <p class="text-slate-300 text-lg">
+          Yes. Press <kbd>Shift</kbd> + <kbd>/</kbd> on any page to open the help
+          overlay.
+        </p>
+      </div>
+      <div>
+        <h2 class="text-2xl font-semibold text-white mb-2 flex items-center">
+          <svg
             class="w-6 h-6 mr-2 text-accent-purple animate-pulse"
             fill="none"
             stroke="currentColor"

--- a/templates/partials/docs_toc.html
+++ b/templates/partials/docs_toc.html
@@ -10,6 +10,7 @@
   <a href="#best-practices" class="toc-link">Best Practices</a>
   <a href="#roles" class="toc-link">User Roles</a>
   <a href="#troubleshooting" class="toc-link">Troubleshooting</a>
+  <a href="#shortcuts" class="toc-link">Keyboard Shortcuts</a>
   <a href="#faq" class="toc-link">FAQ</a>
   <script>
     // Animate active link on scroll


### PR DESCRIPTION
## Summary
- document help overlay shortcut
- expand documentation page and table of contents
- enhance FAQ with more questions
- update help content with shortcut tips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872aa70b0a08333953833d526d086d6