### PR TITLE
Adjust default theme and hero style

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" x-data="{theme: localStorage.theme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark':'light'),showToast:false,toastMsg:''}" :class="{dark: theme==='dark'}" data-theme="dark" x-init="$watch('theme',t=>{localStorage.theme=t;document.documentElement.setAttribute('data-theme',t);})" class="scroll-smooth">
+<html lang="en" x-data="{theme: localStorage.theme || 'light',showToast:false,toastMsg:''}" :class="{dark: theme==='dark'}" data-theme="light" x-init="$watch('theme',t=>{localStorage.theme=t;document.documentElement.setAttribute('data-theme',t);})" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -50,7 +50,7 @@
   </head>
   
   {% with messages = get_flashed_messages(with_categories=true) %}
-  <body class="bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 min-h-screen font-sans antialiased text-white selection:bg-primary-500/20 pt-[var(--header-height)]"
+  <body class="bg-bg min-h-screen font-sans antialiased text-text selection:bg-primary-500/20 pt-[var(--header-height)]"
         style="font-family: 'Inter', system-ui, -apple-system, sans-serif;"
         {% if messages %}data-flashed-messages='{{ messages|tojson|safe }}'{% endif %}
         x-data="{ isScrolled: false }"

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,11 +9,11 @@
 {% endblock %}
 
 {% block hero_title %}
-  <h1 class="text-4xl md:text-5xl font-bold gradient-text">Rules Central</h1>
+  <h1 class="text-4xl md:text-5xl font-bold text-primary-600">Rules Central</h1>
 {% endblock %}
 
 {% block hero_subtitle %}
-  <p class="mt-4 text-lg md:text-xl text-white/70 max-w-2xl mx-auto text-pretty">
+  <p class="mt-4 text-lg md:text-xl text-text-secondary max-w-2xl mx-auto text-pretty">
     Transform your business logic with a cutting-edge AI-powered rules engine. Monitor, analyze, and optimize decision workflows with real-time insights.
   </p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- default to light theme in `base.html`
- simplify body styles for a lighter appearance
- tweak hero styles in `index.html` for consistency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b8a82eb48333a8a164e68890a589