### PR TITLE
Adjust default theme and hero style

### DIFF
--- a/static/css/header.css
+++ b/static/css/header.css
@@ -90,7 +90,7 @@
 
 @layer utilities {
   .glassmorphism {
-    @apply bg-white/5 backdrop-blur-2xl border border-white/10 shadow-glow;
+    @apply bg-white/60 backdrop-blur-md border border-white/20 shadow;
   }
 
   .gradient-text {

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" x-data="{theme: localStorage.theme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark':'light'),showToast:false,toastMsg:''}" :class="{dark: theme==='dark'}" data-theme="dark" x-init="$watch('theme',t=>{localStorage.theme=t;document.documentElement.setAttribute('data-theme',t);})" class="scroll-smooth">
+<html lang="en" x-data="{theme: localStorage.theme || 'light',showToast:false,toastMsg:''}" :class="{dark: theme==='dark'}" data-theme="light" x-init="$watch('theme',t=>{localStorage.theme=t;document.documentElement.setAttribute('data-theme',t);})" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -50,7 +50,7 @@
   </head>
   
   {% with messages = get_flashed_messages(with_categories=true) %}
-  <body class="bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900 min-h-screen font-sans antialiased text-white selection:bg-primary-500/20 pt-[var(--header-height)]"
+  <body class="bg-bg min-h-screen font-sans antialiased text-text selection:bg-primary-500/20 pt-[var(--header-height)]"
         style="font-family: 'Inter', system-ui, -apple-system, sans-serif;"
         {% if messages %}data-flashed-messages='{{ messages|tojson|safe }}'{% endif %}
         x-data="{ isScrolled: false }"

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,11 +9,11 @@
 {% endblock %}
 
 {% block hero_title %}
-  <h1 class="text-4xl md:text-5xl font-bold gradient-text">Rules Central</h1>
+  <h1 class="text-4xl md:text-5xl font-bold text-primary-600">Rules Central</h1>
 {% endblock %}
 
 {% block hero_subtitle %}
-  <p class="mt-4 text-lg md:text-xl text-white/70 max-w-2xl mx-auto text-pretty">
+  <p class="mt-4 text-lg md:text-xl text-text-secondary max-w-2xl mx-auto text-pretty">
     Transform your business logic with a cutting-edge AI-powered rules engine. Monitor, analyze, and optimize decision workflows with real-time insights.
   </p>
 {% endblock %}

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -11,7 +11,7 @@
   {'endpoint': 'main.contact', 'icon': 'fas fa-envelope', 'text': 'Contact'}
 ] %}
 
-<header id="site-header" class="sticky top-0 z-50 card card--glass" x-data="{ mobileMenuOpen: false }" x-cloak>
+<header id="site-header" class="sticky top-0 z-50 bg-white/80 backdrop-blur-md shadow-md" x-data="{ mobileMenuOpen: false }" x-cloak>
   <div class="u-section flex items-center justify-between py-4">
     <!-- Logo -->
     <a href="{{ url_for('main.index') }}" class="flex items-center gap-2 text-xl font-bold text-text">

--- a/templates/partials/hero_bg.html
+++ b/templates/partials/hero_bg.html
@@ -1,14 +1,6 @@
-<div class="hero-section relative py-16 md:py-24 overflow-hidden">
-  <!-- Background Effects -->
-  <div class="absolute inset-0 bg-gradient-to-br from-blue-100/20 via-emerald-100/20 to-transparent backdrop-blur-md"></div>
-  <div class="absolute inset-0" aria-hidden="true">
-    <div class="absolute top-10 left-10 w-32 h-32 bg-blue-300/20 rounded-full filter blur-3xl animate-pulse-slow"></div>
-    <div class="absolute bottom-10 right-10 w-48 h-48 bg-emerald-300/20 rounded-full filter blur-3xl animate-pulse-slow delay-1000"></div>
-  </div>
-
-  <!-- Content -->
-  <div class="u-section relative z-10 text-center">
-    <div class="card card--glass p-8 mx-auto max-w-4xl">
+<div class="hero-section relative py-16 md:py-24 bg-gradient-to-b from-primary-50 to-white">
+  <div class="u-section text-center">
+    <div class="p-8 mx-auto max-w-4xl">
       {% block hero_title %}
         <h1 class="text-4xl md:text-5xl font-bold text-text tracking-tight text-balance">Rules Central</h1>
       {% endblock %}
@@ -28,17 +20,3 @@
     </div>
   </div>
 </div>
-
-<style>
-  @keyframes pulse-slow {
-    0%, 100% { opacity: 0.4; transform: scale(1); }
-    50% { opacity: 0.8; transform: scale(1.1); }
-  }
-  .animate-pulse-slow {
-    animation: pulse-slow 6s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-  }
-  .delay-1000 { animation-delay: 1s; }
-  @media (prefers-reduced-motion) {
-    .animate-pulse-slow { animation: none; }
-  }
-</style>


### PR DESCRIPTION
## Summary
- default to light theme in `base.html`
- simplify body styles for a lighter appearance
- tweak hero styles in `index.html` for consistency
- lighten header and hero sections further for a Bear-like aesthetic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872b8a82eb48333a8a164e68890a589