### PR TITLE
Add bear theme toggle

### DIFF
--- a/static/js/base.js
+++ b/static/js/base.js
@@ -58,46 +58,51 @@ const initTheme = () => {
   const btn = document.getElementById("theme-toggle");
   const icon = btn?.querySelector("i");
 
-  const updateIcon = (theme) => {
-    if (!icon) return;
-    icon.classList.remove("fa-moon", "fa-sun");
-    icon.classList.add(theme === "dark" ? "fa-sun" : "fa-moon");
-    if (btn) btn.setAttribute("aria-pressed", theme === "dark" ? "false" : "true");
+  const THEMES = ["light", "dark", "bear"];
+  const ICONS = {
+    light: "fa-moon",
+    dark: "fa-sun",
+    bear: "fa-paw"
+  };
+
+  const applyTheme = (theme) => {
+    html.setAttribute("data-theme", theme);
+    html.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+    if (icon) {
+      icon.className = `fas ${ICONS[theme]}`;
+    }
+    if (btn) {
+      btn.setAttribute("aria-label", `Toggle theme (current ${theme})`);
+    }
+    if (html.__x && html.__x.$data) {
+      html.__x.$data.theme = theme;
+    }
+    document.dispatchEvent(new CustomEvent("theme-change", { detail: { theme } }));
   };
 
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  const storedTheme =
-    localStorage.getItem("theme") || (prefersDark ? "dark" : "light");
+  const storedTheme = localStorage.getItem("theme") || (prefersDark ? "dark" : "light");
 
-  html.setAttribute("data-theme", storedTheme);
-  if (storedTheme === "dark") html.classList.add("dark");
-  updateIcon(storedTheme);
+  applyTheme(storedTheme);
+  let index = THEMES.indexOf(storedTheme);
+  if (index === -1) index = 0;
 
   let themeListener;
   if (btn) {
-    btn.addEventListener("click", themeListener = () => {
-      const isDark = html.classList.toggle("dark");
-      const theme = isDark ? "dark" : "light";
-      html.setAttribute("data-theme", theme);
-      localStorage.setItem("theme", theme);
-      updateIcon(theme);
-      btn.setAttribute("aria-pressed", theme === "dark" ? "false" : "true");
-      document.dispatchEvent(
-        new CustomEvent("theme-change", { detail: { theme } }),
-      );
-    });
+    btn.addEventListener(
+      "click",
+      (themeListener = () => {
+        index = (index + 1) % THEMES.length;
+        applyTheme(THEMES[index]);
+      })
+    );
   }
 
   const mqListener = (e) => {
     if (!localStorage.getItem("theme")) {
       const newTheme = e.matches ? "dark" : "light";
-      html.setAttribute("data-theme", newTheme);
-      if (newTheme === "dark") {
-        html.classList.add("dark");
-      } else {
-        html.classList.remove("dark");
-      }
-      updateIcon(newTheme);
+      applyTheme(newTheme);
     }
   };
   const mq = window.matchMedia("(prefers-color-scheme: dark)");

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -58,9 +58,18 @@
         </div>
       </div>
 
+      <!-- Theme Toggle -->
+      <button
+        id="theme-toggle"
+        class="p-2 text-text-secondary hover:text-primary-500 focus-ring rounded-md"
+        aria-label="Toggle theme"
+      >
+        <i class="fas fa-moon text-xl"></i>
+      </button>
+
       <!-- Mobile Menu Toggle -->
-      <button 
-        x-on:click="mobileMenuOpen = !mobileMenuOpen" 
+      <button
+        x-on:click="mobileMenuOpen = !mobileMenuOpen"
         class="md:hidden p-2 text-text-secondary hover:text-primary-500 focus-ring rounded-md"
         aria-label="Toggle mobile menu"
         aria-expanded="false"


### PR DESCRIPTION
## Summary
- add a theme switch button in the header
- cycle between light, dark and new "bear" theme

## Testing
- `pytest -q`
- `npm run build:css` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dba232f88333a7728c6d87bcf7bd