### PR TITLE
Add missing new_rule endpoint

### DIFF
--- a/all_routes.py
+++ b/all_routes.py
@@ -17,6 +17,7 @@ from flask import (
     url_for,
     send_file,
     flash,
+    redirect,
     make_response,
 )
 from werkzeug.utils import secure_filename
@@ -377,6 +378,28 @@ def index():
     return render_template(
         "index.html", material=current_app.config.get("MATERIAL"), help_available=True
     )
+
+
+@routes_bp.route("/rules/new", methods=["GET", "POST"])
+def new_rule():
+    """Create a new business rule."""
+    if request.method == "POST":
+        rule_name = request.form.get("name", "").strip()
+        description = request.form.get("description", "").strip()
+        if not rule_name:
+            flash("Rule name is required", "error")
+            return redirect(url_for("routes.new_rule"))
+
+        log_activity(
+            action="create",
+            rule_id=secure_filename(rule_name),
+            user=get_current_user(),
+            details=f"Created new rule '{rule_name}'",
+        )
+        flash(f"Rule '{rule_name}' created!", "success")
+        return redirect(url_for("routes.catalog"))
+
+    return render_template("new_rule.html", help_available=True)
 
 
 @routes_bp.route("/catalog")

--- a/templates/new_rule.html
+++ b/templates/new_rule.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% from 'macros/components.html' import input, button %}
+{% block title %}Create Rule | Rules Central{% endblock %}
+{% block hero_title %}Create&nbsp;a&nbsp;New&nbsp;Rule{% endblock %}
+{% block hero_subtitle %}Define a new rule using the form below.{% endblock %}
+{% block content %}
+<section class="u-section py-12">
+  <div class="card--glass glassmorphism p-8 rounded-2xl">
+    <form method="post" class="space-y-6">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="form-group">
+        <label for="name" class="block text-slate-400 mb-2">Rule Name</label>
+        {{ input('name', placeholder='Payment Validation') }}
+      </div>
+      <div class="form-group">
+        <label for="description" class="block text-slate-400 mb-2">Description</label>
+        <textarea id="description" name="description" class="input focus-ring min-h-[100px]"></textarea>
+      </div>
+      <div>
+        {{ button('Create Rule') }}
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a `new_rule` route with form handling
- create `new_rule.html` template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872df7fb4a483339c3c705b2b2eb49a