### PR TITLE
Fix missing activity route

### DIFF
--- a/all_routes.py
+++ b/all_routes.py
@@ -444,6 +444,12 @@ def search():
     return render_template("search.html", help_available=True)
 
 
+@routes_bp.route("/activity")
+def activity():
+    """Display recent activity logs."""
+    return render_template("activity.html", help_available=True)
+
+
 @routes_bp.route("/config")
 def config_page():
     """Configuration view"""

--- a/templates/activity.html
+++ b/templates/activity.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Activity{% endblock %}
+{% block hero_title %}Activity Log{% endblock %}
+{% block hero_subtitle %}Recent actions across the system.{% endblock %}
+{% block content %}
+<section class="u-section py-12">
+  <h1 class="sr-only">Activity</h1>
+  <div class="card--glass glassmorphism p-6 rounded-2xl">
+    <p class="text-slate-400">Activity details coming soon.</p>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add an `/activity` route to serve a new Activity page
- include the Activity template with placeholder content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e6556e74833388b786c152c0db41