### PR TITLE
Apply Bear theme

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -17,6 +17,12 @@
   border: var(--glass-border);
 }
 
+/* Bear theme tweaks */
+[data-theme="bear"] .glass {
+  --glass-bg: rgba(255, 255, 255, 0.6);
+  --glass-border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
 /* Card Hover Effects */
 .card-hover {
   transition: transform 0.2s ease, box-shadow 0.2s ease;

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -81,8 +81,7 @@ const initTheme = () => {
     document.dispatchEvent(new CustomEvent("theme-change", { detail: { theme } }));
   };
 
-  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  const storedTheme = localStorage.getItem("theme") || (prefersDark ? "dark" : "light");
+  const storedTheme = localStorage.getItem("theme") || "bear";
 
   applyTheme(storedTheme);
   let index = THEMES.indexOf(storedTheme);

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" x-data="{theme: localStorage.theme || 'light',showToast:false,toastMsg:''}" :class="{dark: theme==='dark'}" data-theme="light" x-init="$watch('theme',t=>{localStorage.theme=t;document.documentElement.setAttribute('data-theme',t);})" class="scroll-smooth">
+<html lang="en" x-data="{theme: localStorage.theme || 'bear',showToast:false,toastMsg:''}" :class="{dark: theme==='dark'}" data-theme="bear" x-init="$watch('theme',t=>{localStorage.theme=t;document.documentElement.setAttribute('data-theme',t);})" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
 
 {% block hero_subtitle %}
   <p class="mt-4 text-lg md:text-xl text-text-secondary max-w-2xl mx-auto text-pretty">
-    Transform your business logic with a cutting-edge AI-powered rules engine. Monitor, analyze, and optimize decision workflows with real-time insights.
+    Inspired by the clean aesthetic of Bear Notes, manage your rules with focus and clarity.
   </p>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- default to the "bear" theme in `base.html`
- default theme to "bear" in `base.js`
- mention Bear Notes style on the dashboard page
- tweak glass effect colors when using Bear theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68731a7430dc833386bd64e031af0e68