### PR TITLE
Wire up UI routes

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,16 +1,45 @@
 """Authentication routes."""
 
-from flask import Blueprint, current_app, jsonify
+from flask import (
+    Blueprint,
+    current_app,
+    jsonify,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+)
 
 auth = Blueprint("auth", __name__)
 
 
-@auth.route("/login")
+@auth.route("/login", methods=["GET", "POST"])
 def login():
-    """Simple login endpoint placeholder."""
+    """Render the login page and handle submissions."""
 
     try:
-        return "Login Page"
+        if request.method == "POST":
+            # Placeholder authentication logic
+            flash("Logged in successfully!", "success")
+            return redirect(url_for("routes.index"))
+
+        return render_template("auth/login.html")
     except Exception as exc:
         current_app.logger.error("Login route error: %s", exc)
         return jsonify(error="Login failure"), 500
+
+
+@auth.route("/register", methods=["GET", "POST"])
+def register():
+    """Render the registration page and handle submissions."""
+
+    try:
+        if request.method == "POST":
+            flash("Account created!", "success")
+            return redirect(url_for("auth.login"))
+
+        return render_template("auth/register.html")
+    except Exception as exc:
+        current_app.logger.error("Register route error: %s", exc)
+        return jsonify(error="Registration failure"), 500

--- a/routes/collab.py
+++ b/routes/collab.py
@@ -1,16 +1,32 @@
 """Collaboration routes."""
 
-from flask import Blueprint, current_app, jsonify
+from flask import (
+    Blueprint,
+    current_app,
+    jsonify,
+    render_template,
+)
 
 collab = Blueprint("collab", __name__)
 
 
 @collab.route("/collab")
 def collab_index():
-    """Placeholder collaboration page."""
+    """Collaboration hub main page."""
 
     try:
-        return "Collaboration Home"
+        return render_template("collab/index.html")
     except Exception as exc:
         current_app.logger.error("Collab route error: %s", exc)
+        return jsonify(error="Collaboration service unavailable"), 500
+
+
+@collab.route("/collab/team")
+def team():
+    """Team management page."""
+
+    try:
+        return render_template("collab/team.html")
+    except Exception as exc:
+        current_app.logger.error("Collab team route error: %s", exc)
         return jsonify(error="Collaboration service unavailable"), 500

--- a/routes/diagrams.py
+++ b/routes/diagrams.py
@@ -1,16 +1,21 @@
 """Simple diagrams route placeholder."""
 
-from flask import Blueprint, current_app, jsonify
+from flask import (
+    Blueprint,
+    current_app,
+    jsonify,
+    render_template,
+)
 
 diagrams = Blueprint("diagrams", __name__)
 
 
 @diagrams.route("/diagrams")
 def diagrams_index():
-    """Return a placeholder message for diagrams."""
+    """Display the diagram viewer page."""
 
     try:
-        return "Diagrams Home"
+        return render_template("diagram_viewer.html")
     except Exception as exc:
         current_app.logger.error("Diagrams route error: %s", exc)
         return jsonify(error="Unable to load diagrams"), 500

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -60,4 +60,5 @@
 {% block scripts %}
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <script src="{{ url_for('static', filename='js/login.js') }}" defer></script>
 {% endblock %}

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -15,3 +15,6 @@
   <a href="{{ url_for('routes.index') }}" class="text-primary-400 hover:underline">Already have an account?</a>
 </p>
 {% endblock %}
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/register.js') }}" defer></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- render login and registration templates
- connect collaboration and diagrams endpoints to templates
- include page scripts for auth pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e2a614f48333ae8394fe5fea0e79