### PR TITLE
Apply bear theme styling

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -33,20 +33,20 @@
   }
 
   [data-theme="bear"] {
-    --bg: #f5efe6;
-    --bg-elevated: #ede2d1;
-    --bg-surface: #f7f3eb;
-    --bg-overlay: #e8d9c4;
-    --text: #4a2c2a;
-    --border: #d9c1a3;
-    --focus-ring: #8b5e34;
-    --primary-500: #8b5e34;
-    --primary-600: #724c29;
-    --primary-700: #593b22;
-    --primary-800: #432e1a;
-    --secondary-400: #d9a66c;
-    --secondary-700: #ab803b;
-    --font-sans: 'Cabin', 'Avenir Next', 'Helvetica Neue', -apple-system, sans-serif;
+    --bg: #fffdfa;
+    --bg-elevated: #fff5ef;
+    --bg-surface: #fffaf7;
+    --bg-overlay: #fdefe6;
+    --text: #40322f;
+    --border: #ffd4c7;
+    --focus-ring: #FF5E62;
+    --primary-500: #FF5E62;
+    --primary-600: #FF5E62;
+    --primary-700: #E04E4D;
+    --primary-800: #B03737;
+    --secondary-400: #FFC371;
+    --secondary-700: #E89E5E;
+    --font-sans: 'Nunito', 'Inter', sans-serif;
   }
 
   body {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -6,11 +6,11 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#28C76F',
-          600: '#28C76F',
-          700: '#1fa85b',
-          gradientStart: '#667eea',
-          gradientEnd: '#764ba2'
+          DEFAULT: '#FF5E62',
+          600: '#FF5E62',
+          700: '#E04E4D',
+          gradientStart: '#FF5E62',
+          gradientEnd: '#FFC371'
         },
         danger: {
           gradientStart: '#ff6b6b',
@@ -28,7 +28,7 @@ module.exports = {
         }
       },
       fontFamily: {
-        sans: ['Inter', 'sans-serif']
+        sans: ['\'Nunito\'', 'Inter', 'sans-serif']
       },
       boxShadow: {
         soft: '0 2px 6px rgb(0 0 0 / 0.2)',

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 <!doctype html>
-<html lang="en" x-data="{theme: localStorage.theme || 'light', showToast: false, toastMsg: ''}" 
-      :class="{'dark': theme==='dark'}" 
-      data-theme="light" 
+<html lang="en" x-data="{theme: localStorage.theme || 'bear', showToast: false, toastMsg: ''}"
+      :class="{'dark': theme==='dark'}"
+      data-theme="bear"
       x-init="$watch('theme', t => {
         localStorage.theme = t;
         document.documentElement.setAttribute('data-theme', t);
@@ -11,8 +11,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark light" />
-    <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)">
-    <meta name="theme-color" content="#f3f4f6" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#FF5E62" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#FF5E62" media="(prefers-color-scheme: light)">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     
     {% block meta %}
     <meta name="description" content="Rules Central: AI-powered rules engine for business automation">

--- a/templates/partials/hero_bg.html
+++ b/templates/partials/hero_bg.html
@@ -1,4 +1,4 @@
-<section class="hero relative bg-gradient-to-r from-blue-600 to-purple-600 text-white py-20 md:py-32">
+<section class="hero relative bg-gradient-to-r from-primary-gradientStart to-primary-gradientEnd text-white py-20 md:py-32">
   <div class="hero-overlay absolute inset-0 bg-black/20"></div>
   <div class="hero-content container mx-auto px-4 relative z-10 text-center">
     {% block hero_title %}


### PR DESCRIPTION
## Summary
- tweak Tailwind palette and default font
- add Bear color scheme in custom CSS
- switch base template default to Bear theme and load Nunito font
- use primary gradient in hero section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e51fa7808333b43113c8c3df4dad