### PR TITLE
Add Bear-style marketing page

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -16,6 +16,13 @@ module.exports = {
           gradientStart: '#ff6b6b',
           gradientEnd: '#ee5a24'
         },
+        'surface-white': '#FFFFFF',
+        'surface-shade': '#FAFAFA',
+        'ink-900': '#1C1C1E',
+        'ink-600': '#444448',
+        'ink-400': '#94949A',
+        'accent-red': '#FF3B30',
+        'accent-red-dark': '#FF453A',
         status: {
           active: '#22c55e',
           draft: '#fbbf24',
@@ -28,12 +35,16 @@ module.exports = {
         }
       },
       fontFamily: {
-        sans: ['\'Nunito\'', 'Inter', 'sans-serif']
+        sans: ['\'SF Pro\'', 'Inter', 'system-ui', 'sans-serif']
       },
       boxShadow: {
-        soft: '0 2px 6px rgb(0 0 0 / 0.2)',
+        soft: '0 2px 8px rgb(0 0 0 / 0.08)',
         glow: '0 8px 32px rgba(0, 0, 0, 0.3)',
         pulse: '0 0 20px rgba(59, 130, 246, 0.3)'
+      },
+      spacing: {
+        18: '4.5rem',
+        22: '5.5rem'
       },
       animation: {
         float: 'float 3s ease-in-out infinite',

--- a/templates/_components/macros.html
+++ b/templates/_components/macros.html
@@ -1,0 +1,98 @@
+{% macro Nav() -%}
+<nav class="sticky top-0 z-50 bg-surface-white dark:bg-ink-900 shadow-sm">
+  <div class="max-w-7xl mx-auto flex items-center justify-between px-4 py-4">
+    <a href="/" class="font-semibold text-lg">Rules Central</a>
+    <ul class="hidden md:flex gap-8 text-sm">
+      <li><a href="#features" class="hover:text-accent-red">Features</a></li>
+      <li><a href="#pricing" class="hover:text-accent-red">Pricing</a></li>
+      <li><a href="#contact" class="hover:text-accent-red">Contact</a></li>
+    </ul>
+    <button id="theme-toggle" class="ml-4 p-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red" aria-label="Toggle theme" @click="toggleTheme()">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-8.66h-1M4.34 12H3m13.07-5.07l-.71.71M6.64 17.36l-.71.71m11.07 0l-.71-.71M6.64 6.64l-.71-.71"/></svg>
+    </button>
+  </div>
+</nav>
+{%- endmacro %}
+
+{% macro Hero() -%}
+<section class="relative overflow-hidden bg-surface-shade dark:bg-ink-900 py-22">
+  <div class="relative z-10 max-w-3xl mx-auto text-center px-4">
+    <h1 class="text-4xl md:text-6xl font-bold mb-4">Rule management you\u2019ll love</h1>
+    <p class="text-lg text-ink-600 dark:text-ink-400 mb-8">Organize and automate your rules with delightful simplicity.</p>
+    <a href="#pricing" class="btn-primary inline-block">Get started free</a>
+  </div>
+  <div class="pointer-events-none absolute inset-0 flex justify-center">
+    <img src="{{ url_for('static', filename='images/hero-macbook.webp') }}" alt="MacBook screenshot" class="hidden md:block w-1/2 max-w-lg shadow-soft absolute -top-10 left-1/2 -translate-x-1/2" loading="lazy">
+    <img src="{{ url_for('static', filename='images/hero-iphone.webp') }}" alt="iPhone screenshot" class="w-1/4 max-w-xs shadow-soft absolute top-12 left-[10%]" loading="lazy">
+    <img src="{{ url_for('static', filename='images/hero-ipad.webp') }}" alt="iPad screenshot" class="w-1/3 max-w-md shadow-soft absolute top-20 right-[10%]" loading="lazy">
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro FeatureRow(title, body, image, bg='surface-white', reverse=false) -%}
+<section class="py-22 bg-{{ bg }} dark:bg-ink-900">
+  <div class="max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-16 px-4 {% if reverse %}md:flex-row-reverse{% endif %}">
+    <div class="md:w-1/2">
+      <h2 class="text-3xl font-semibold mb-4">{{ title }}</h2>
+      <p class="text-lg text-ink-600 dark:text-ink-400 leading-relaxed">{{ body }}</p>
+    </div>
+    <img src="{{ url_for('static', filename=image) }}" alt="" class="md:w-1/2 w-full shadow-soft" loading="lazy">
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro PriceCards() -%}
+<section id="pricing" class="bg-surface-white dark:bg-ink-900 py-22">
+  <div class="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 px-4">
+    <div class="border rounded-lg shadow-soft p-8 flex flex-col">
+      <h3 class="text-xl font-semibold mb-4">Free</h3>
+      <p class="text-4xl font-bold mb-6">$0</p>
+      <ul class="flex-1 space-y-2 mb-6 text-ink-600 dark:text-ink-400">
+        <li>Unlimited rules</li>
+        <li>Community support</li>
+      </ul>
+      <a href="#" class="btn-primary mt-auto text-center">Get started</a>
+    </div>
+    <div class="border rounded-lg shadow-soft p-8 flex flex-col relative">
+      <span class="absolute -top-3 right-3 bg-accent-red text-white text-xs px-2 py-1 rounded">Pro</span>
+      <h3 class="text-xl font-semibold mb-4">Pro</h3>
+      <p class="text-4xl font-bold mb-6">$12<span class="text-base font-normal">/mo</span></p>
+      <ul class="flex-1 space-y-2 mb-6 text-ink-600 dark:text-ink-400">
+        <li>Team collaboration</li>
+        <li>Priority support</li>
+        <li>PDF / PNG export</li>
+      </ul>
+      <a href="#" class="btn-primary mt-auto text-center">Start trial</a>
+    </div>
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro Footer() -%}
+<footer id="contact" class="bg-surface-shade dark:bg-ink-900 text-sm mt-auto py-22">
+  <div class="max-w-7xl mx-auto grid md:grid-cols-2 gap-8 px-4">
+    <nav>
+      <ul class="space-y-2">
+        <li><a href="#features" class="hover:text-accent-red">Features</a></li>
+        <li><a href="#pricing" class="hover:text-accent-red">Pricing</a></li>
+        <li><a href="#contact" class="hover:text-accent-red">Contact</a></li>
+      </ul>
+    </nav>
+    <form class="flex flex-col gap-4">
+      <label for="newsletter" class="font-semibold">Newsletter</label>
+      <input id="newsletter" type="email" required placeholder="you@example.com" class="px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-accent-red" />
+      <button type="submit" class="btn-primary self-start">Subscribe</button>
+    </form>
+  </div>
+</footer>
+{%- endmacro %}
+
+{% macro LogoRow() -%}
+<section class="bg-surface-white dark:bg-ink-900 py-16" id="logos">
+  <div class="max-w-7xl mx-auto flex justify-center gap-12 opacity-80 px-4">
+    {% for logo in ['logo1.svg','logo2.svg','logo3.svg','logo4.svg'] %}
+      <img src="{{ url_for('static', filename='images/' + logo) }}" alt="" class="h-16 w-auto grayscale" loading="lazy">
+    {% endfor %}
+  </div>
+</section>
+{%- endmacro %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth antialiased text-ink-900 dark:bg-ink-900 dark:text-surface" x-data="{dark: localStorage.theme === 'dark'}" x-init="$watch('dark', val => document.documentElement.classList.toggle('dark', val))">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rules Central — Bear-style Landing Page</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+      @tailwind base;
+      @tailwind components;
+      @tailwind utilities;
+      @layer components {
+        .btn-primary { @apply bg-accent-red dark:bg-accent-red-dark text-white px-6 py-3 rounded-md shadow-soft transition-transform duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red; }
+      }
+      @media (hover:hover){ .btn-primary:hover{ @apply scale-105; } }
+      @media (prefers-reduced-motion: reduce){ .btn-primary:hover{ @apply scale-100; } }
+    </style>
+  </head>
+  <body class="flex flex-col min-h-screen">
+    {% from "_components/macros.html" import Nav, Hero, FeatureRow, PriceCards, Footer, LogoRow %}
+    {{ Nav() }}
+    <main id="main">
+      {{ Hero() }}
+      {{ FeatureRow('Fuzzy search that never misses', 'Find the rule you need instantly with tolerant search options.', 'images/feature-search.webp', 'surface-white') }}
+      {{ FeatureRow('Visual query builder', 'Construct complex rule queries without writing code.', 'images/feature-query.webp', 'surface-shade', true) }}
+      {{ FeatureRow('One-click PDF / PNG export', 'Share your rule sets with clean exports perfect for reports.', 'images/feature-export.webp', 'surface-white') }}
+      {{ LogoRow() }}
+      {{ PriceCards() }}
+      <section class="bg-accent-red dark:bg-accent-red-dark text-white text-center py-16">
+        <h2 class="text-3xl font-semibold mb-4">Ready to get started?</h2>
+        <a href="#" class="btn-primary">Create your free account</a>
+      </section>
+    </main>
+    {{ Footer() }}
+    <script>
+      function toggleTheme(){
+        dark = !dark;
+        localStorage.theme = dark ? 'dark' : 'light';
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- extend Tailwind theme with Bear colors, font, box shadow and spacing
- add reusable Jinja macros for Nav, Hero, FeatureRow, PriceCards and Footer
- implement new `home.html` landing page using the macros

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e8da4f508333b7676f708870d994