### PR TITLE
Add Bear-style UI macros and Tailwind theme

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,9 @@ module.exports = {
       boxShadow: {
         soft: '0 2px 8px rgba(0,0,0,.04)'
       },
+      rotate: {
+        360: '360deg'
+      },
       keyframes: {
         'fade-up': {
           from: { opacity: '0', transform: 'translateY(8px)' },

--- a/templates/_components/macros.html
+++ b/templates/_components/macros.html
@@ -17,7 +17,7 @@
 {% macro DeviceCarousel(images) -%}
 <div x-data="carousel({{ images|length }})" class="relative aspect-[3/2] overflow-hidden">
   {% for img in images %}
-  <picture class="absolute inset-0" x-show="current === {{ loop.index0 }}" x-transition.opacity.duration.700ms>
+  <picture class="absolute inset-0 transition-opacity duration-700 motion-reduce:duration-0" :class="current === {{ loop.index0 }} ? 'opacity-100' : 'opacity-0'">
     <source srcset="{{ url_for('static', filename=img + '.avif') }}" type="image/avif">
     <source srcset="{{ url_for('static', filename=img + '.webp') }}" type="image/webp">
     <img src="{{ url_for('static', filename=img + '.png') }}" alt="" class="w-full h-full object-cover" loading="lazy" decoding="async">
@@ -79,7 +79,7 @@ function carousel(count){return{current:0,timer:null,init(){let o=new Intersecti
     <div x-data="{open:false}" class="py-4">
       <button type="button" @click="open=!open" @keydown.enter.prevent="open=!open" @keydown.space.prevent="open=!open" class="w-full flex justify-between items-center text-left font-medium focus-visible:ring-2 focus-visible:ring-[var(--accent-r)]">
         <span>{{ q }}</span>
-        <svg class="w-5 h-5 transform transition-transform" :class="{'rotate-180':open}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.292l3.71-4.06a.75.75 0 111.08 1.04l-4.25 4.657a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
+        <svg class="w-5 h-5 transform transition-transform" :class="{'rotate-360':open}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.292l3.71-4.06a.75.75 0 111.08 1.04l-4.25 4.657a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
       </button>
       <div x-show="open" x-collapse class="mt-2 text-[var(--ink-600)] dark:text-[var(--ink-400)]">{{ a }}</div>
     </div>


### PR DESCRIPTION
## Summary
- customize Tailwind theme with Bear 2025 tokens
- add rotate-360 utility and update carousel markup
- update macros to respect reduced motion and rotate the FAQ chevron

## Testing
- `npx tailwindcss -i src/input.css -o static/css/app.css --minify`

------
https://chatgpt.com/codex/tasks/task_e_6873f44b8a4c8333b719e082466fb902