### PR TITLE
Fix nav active link error

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -16,11 +16,11 @@
     <!-- Desktop Nav -->
     <nav class="desktop-nav hidden md:block">
       {{ render_nav_links([
-        {'url': url_for('routes.index'), 'text': 'Home'},
-        {'url': url_for('routes.catalog'), 'text': 'Catalog'},
-        {'url': url_for('routes.search'), 'text': 'Search'},
-        {'url': url_for('routes.analytics'), 'text': 'Analytics'},
-        {'url': url_for('routes.about'), 'text': 'About'}
+        {'endpoint': 'routes.index', 'text': 'Home'},
+        {'endpoint': 'routes.catalog', 'text': 'Catalog'},
+        {'endpoint': 'routes.search', 'text': 'Search'},
+        {'endpoint': 'routes.analytics', 'text': 'Analytics'},
+        {'endpoint': 'routes.about', 'text': 'About'}
       ])}}
     </nav>
 
@@ -78,11 +78,11 @@
        x-transition>
     <div class="mobile-nav-content container mx-auto px-4 py-3">
       {{ render_nav_links([
-        {'url': url_for('routes.index'), 'text': 'Home'},
-        {'url': url_for('routes.catalog'), 'text': 'Catalog'},
-        {'url': url_for('routes.search'), 'text': 'Search'},
-        {'url': url_for('routes.analytics'), 'text': 'Analytics'},
-        {'url': url_for('routes.about'), 'text': 'About'}
+        {'endpoint': 'routes.index', 'text': 'Home'},
+        {'endpoint': 'routes.catalog', 'text': 'Catalog'},
+        {'endpoint': 'routes.search', 'text': 'Search'},
+        {'endpoint': 'routes.analytics', 'text': 'Analytics'},
+        {'endpoint': 'routes.about', 'text': 'About'}
       ], is_mobile=true)}}
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- fix type error from nav_links macro when `item.endpoint` was missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873fc5d1fc48333a417976c7d406ac1