### PR TITLE
Remove inline styles

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -138,4 +138,14 @@
   .space-y-6 > * + * {
     margin-top: 1.5rem;
   }
+
+  /* Progress bars */
+  .progress-container {
+    @apply bg-white/10 rounded-full overflow-hidden h-1.5;
+  }
+
+  .progress-fill {
+    @apply bg-primary-500 h-full transition-[width] duration-300;
+    width: var(--progress, 0%);
+  }
 }

--- a/static/css/custom-utilities.css
+++ b/static/css/custom-utilities.css
@@ -54,4 +54,14 @@
   .fab-delay-1 { --i: 1; }
   .fab-delay-2 { --i: 2; }
   .fab-delay-3 { --i: 3; }
+
+  /* Progress bar utilities */
+  .progress-container {
+    @apply bg-white/10 rounded-full overflow-hidden h-1.5;
+  }
+
+  .progress-fill {
+    @apply bg-primary-500 h-full transition-[width] duration-300;
+    width: var(--progress, 0%);
+  }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -65,9 +65,8 @@
 
     <!-- Progress Bar -->
     <div id="scroll-progress"
-         class="fixed top-0 left-0 h-1 bg-primary-500 z-50 transition-opacity duration-300"
-         :class="{ 'opacity-0': !isScrolled }"
-         style="width: var(--scroll-percentage, 0%)"></div>
+         class="fixed top-0 left-0 h-1 bg-primary-500 z-50 transition-opacity duration-300 progress-fill"
+         :class="{ 'opacity-0': !isScrolled }"></div>
 
     {% include 'partials/header.html' %}
     

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,9 @@
             </div>
             {% if stat.progress < 100 %}
               <div class="stat-progress">
-                <div class="progress-bar" style="width: {{ stat.progress }}%"></div>
+                <div class="progress-bar">
+                  <div class="progress-fill" style="--progress: {{ stat.progress }}%"></div>
+                </div>
               </div>
             {% endif %}
           </div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -73,10 +73,9 @@
     </div>
 
     <!-- Progress bar -->
-    <div class="h-2 rounded-full bg-slate-700/50 overflow-hidden transition-opacity duration-300"
+    <div class="progress-bar h-2 bg-slate-700/50 overflow-hidden transition-opacity duration-300"
          :class="isLoading ? 'opacity-100' : 'opacity-0'">
-      <div class="h-full bg-primary-500"
-           :style="`width: ${progress}%`"></div>
+      <div class="progress-fill" :style="`--progress: ${progress}%`"></div>
     </div>
   </form>
   </div>


### PR DESCRIPTION
## Summary
- move progress bar inline styles to Tailwind utility classes
- define reusable progress utilities in Tailwind CSS

## Testing
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_6874002d63848333adf80f8ad84de078