### PR TITLE
Fix asset link in hierarchy template

### DIFF
--- a/templates/hierarchy_viewer.html
+++ b/templates/hierarchy_viewer.html
@@ -147,5 +147,5 @@
   {{ super() }}
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-  <script src="/static/js/hierarchy_viewer.js" defer></script>
+  <script defer src="{{ url_for('static', filename='js/hierarchy_viewer.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- correct script source in `hierarchy_viewer.html` to use `url_for`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740c3cff208333914d43fe5737aa69