### PR TITLE
Fix profile link in header

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -50,7 +50,7 @@
             <p class="font-medium text-gray-800 dark:text-white">Signed in as</p>
             <p class="text-sm text-gray-500 dark:text-gray-400 truncate">user@example.com</p>
           </div>
-          <a href="{{ url_for('routes.profile') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+          <a href="{{ url_for('user_routes.user_profile') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
             Your Profile
           </a>
           <a href="{{ url_for('auth.logout') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">


### PR DESCRIPTION
## Summary
- link to the correct user profile endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687434b47b3c8333a9780fbc108679a1