### PR TITLE
Add CSRF tokens to key forms

### DIFF
--- a/templates/contact.html
+++ b/templates/contact.html
@@ -33,6 +33,7 @@
         method="post"
         aria-label="Contact form"
       >
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="form-group">
           <label
             class="block text-slate-400 mb-2 text-md font-medium"

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -43,6 +43,7 @@
       </div>
 
       <form class="p-6 space-y-6" method="post" aria-label="Edit profile form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div>
           <label class="block text-slate-400 mb-2 font-medium" for="username"
             >Username</label

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -18,6 +18,7 @@
     aria-label="Settings form"
     @submit="isLoading = true"
   >
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <!-- Profile Section -->
     <div
       class="card--glass glassmorphism card-hover p-10 rounded-2xl"


### PR DESCRIPTION
## Summary
- inject CSRF tokens into contact, profile and settings forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874605c2b8c83339b3fb2f08d700fd1