### PR TITLE
Refactor utils modules

### DIFF
--- a/utils/diagram_utils.py
+++ b/utils/diagram_utils.py
@@ -1,6 +1,6 @@
 import json
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import logging
 from pathlib import Path
@@ -31,20 +31,25 @@ def diagram_type_from_filename(filename: str) -> str | None:
     return None
 
 
-def generate_files(json_data: list, output_dir: str) -> None:
-    """Process the input JSON data and generate output files."""
+def generate_files(json_data: list, output_dir: str) -> list[DiagramInfo]:
+    """Process ``json_data`` and generate diagram and JSON files."""
     LOGGER.info("Processing %d rules...", len(json_data))
     os.makedirs(output_dir, exist_ok=True)
     propagate_disabled_rules(json_data)
     flat_rules = flatten_rules(json_data)
     edges, _ = build_all_edges(json_data)
     edge_map = build_edge_map(edges)
-    LOGGER.info("Processed %d flat rules and %d edges.", len(flat_rules), len(edges))
+    LOGGER.info(
+        "Processed %d flat rules and %d edges.",
+        len(flat_rules),
+        len(edges),
+    )
     container_groups: Dict[str, list] = {}
     for rule in flat_rules:
         container = rule.get("Container") or os.path.basename(output_dir)
         container_groups.setdefault(container, []).append(rule)
     root_name = os.path.basename(output_dir)
+    infos: list[DiagramInfo] = []
     for container, rules in container_groups.items():
         group_ids = {r["RuleGUID"] for r in rules}
         group_nodes = build_nodes(
@@ -65,17 +70,20 @@ def generate_files(json_data: list, output_dir: str) -> None:
         with open(diagram_path, "w", encoding="utf-8") as f:
             f.write(mermaid_code)
         info = DiagramInfo(diagram_filename, datetime.now(timezone.utc).isoformat())
+        infos.append(info)
         LOGGER.info("Created diagram %s", info.filename)
         with open(os.path.join(output_dir, f"{sanitized_container}.json"), "w", encoding="utf-8") as f:
             json.dump({"rules": rules}, f, indent=4)
+    return infos
 
 
 # Support functions -----------------------------------------------------------
 
-def generate_mermaid_code(nodes, edges, layout="TD"):
+def generate_mermaid_code(nodes: Dict[str, Dict[str, str]], edges: Iterable[Dict[str, str]], layout: str = "TD") -> str:
+    """Convert nodes and edges into a simple mermaid diagram string."""
     lines = [f"graph {layout}"]
     for node_id, node in nodes.items():
         lines.append(f"{node_id}[{node['label']}]")
-    for e in edges:
-        lines.append(e["edge_str"])
+    for edge in edges:
+        lines.append(edge["edge_str"])
     return "\n".join(lines)

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -3,8 +3,6 @@ from pathlib import Path
 from typing import Any, Dict, Iterable
 import logging
 
-from .file_utils import ensure_directory_exists
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/utils/rule_utils.py
+++ b/utils/rule_utils.py
@@ -74,8 +74,10 @@ def flatten_rules(rules: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return flat_list
 
 
-def propagate_disabled_rules(rules, inherited_disabled=False):
-    """Propagate the disabled state through the rules."""
+def propagate_disabled_rules(
+    rules: Iterable[Dict[str, Any]], inherited_disabled: bool = False
+) -> None:
+    """Propagate the disabled state through the rules in-place."""
     for rule in rules:
         current_disabled = inherited_disabled or (
             rule.get("Attributes", {}).get("_Disabled") in ["1", 1, True]


### PR DESCRIPTION
## Summary
- clean up unused imports
- make `propagate_disabled_rules` type safe
- make `generate_files` return a list of `DiagramInfo`
- document `generate_mermaid_code`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687470d3908c83338ea38b4fa5f78e92