### PR TITLE
Add new Markdown Notes marketing page

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -105,3 +105,12 @@ def contact():
     except Exception as exc:  # pragma: no cover - unexpected errors
         current_app.logger.error("Contact page error: %s", exc)
         abort(500)
+
+@main.route("/markdown-notes")
+def markdown_notes():
+    """Show the Markdown Notes marketing page."""
+    try:
+        return render_template("markdown_notes.html")
+    except Exception as exc:
+        current_app.logger.error("Markdown Notes page error: %s", exc)
+        abort(500)

--- a/templates/markdown_notes.html
+++ b/templates/markdown_notes.html
@@ -1,0 +1,179 @@
+{% extends "base.html" %}
+{% block head %}
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; }
+  </style>
+{% endblock %}
+{% block content %}
+<div class="bg-white text-black">
+  <div class="max-w-7xl mx-auto px-6 sm:px-10 md:px-16 lg:px-20 xl:px-24">
+   <!-- Header -->
+   <header class="pt-20 text-center max-w-xl mx-auto">
+    <h1 class="text-[22px] sm:text-[28px] md:text-[32px] font-semibold leading-tight">
+     Markdown notes you’ll love
+    </h1>
+    <p class="mt-3 text-[14px] sm:text-[16px] text-gray-600">
+     Write naturally, organize easily, and share securely.
+    </p>
+    <a href="#" class="inline-block mt-6 bg-black text-white text-[14px] sm:text-[16px] font-semibold rounded-md px-8 py-3 hover:bg-gray-900 transition">
+     Get it on iOS
+    </a>
+   </header>
+   <!-- Hero Image Section -->
+   <section class="mt-20 flex justify-center relative max-w-4xl mx-auto">
+    <img src="https://storage.googleapis.com/a1aa/image/7e987eb2-a260-4163-51d6-c098dadf3a0b.jpg" alt="Stack of mobile app screens showing markdown notes, with a white phone frame in front" class="w-[360px] h-[600px] object-contain" width="360" height="600"/>
+   </section>
+   <!-- Write naturally section -->
+   <section class="mt-28 max-w-3xl mx-auto text-center px-4">
+    <h2 class="text-[22px] sm:text-[28px] md:text-[32px] font-semibold leading-tight">
+     Write naturally
+    </h2>
+    <p class="mt-3 text-[14px] sm:text-[16px] text-gray-600">
+     Use Markdown to format your notes quickly and easily, with live preview.
+    </p>
+    <img src="https://storage.googleapis.com/a1aa/image/54610db5-a76d-4794-50b0-7bcd8039e97c.jpg" alt="Screenshot of a markdown editor with live preview showing a note about Markdown syntax" class="mt-8 mx-auto rounded-lg shadow-md w-full max-w-[720px]" width="720" height="320"/>
+   </section>
+   <!-- Features sections with colored blobs -->
+   <section class="mt-28 space-y-28 max-w-5xl mx-auto px-4">
+    <!-- Seamless Markdown -->
+    <div class="relative flex flex-col md:flex-row items-center md:items-start md:space-x-12">
+     <div aria-hidden="true" class="absolute -top-20 -left-20 w-[280px] h-[280px] bg-[#A7D8F0] rounded-[120px] opacity-40 -z-10"></div>
+     <div class="md:w-1/2 text-center md:text-left">
+      <h3 class="text-[20px] sm:text-[24px] font-semibold text-[#1E40AF]">Seamless Markdown</h3>
+      <p class="mt-3 text-[14px] sm:text-[16px] text-gray-700 max-w-md mx-auto md:mx-0">Write in Markdown with a smooth, distraction-free interface that supports all your formatting needs.</p>
+     </div>
+     <div class="md:w-1/2 mt-8 md:mt-0 flex justify-center md:justify-end">
+      <img src="https://storage.googleapis.com/a1aa/image/661031f3-1e43-449d-193b-21bdbb47b784.jpg" alt="Screenshot showing seamless markdown editing interface with toolbar and preview" class="rounded-lg shadow-md w-full max-w-[360px]" width="360" height="280"/>
+     </div>
+    </div>
+    <!-- Organize easily -->
+    <div class="relative flex flex-col md:flex-row-reverse items-center md:items-start md:space-x-0 md:space-x-reverse md:space-x-12">
+     <div aria-hidden="true" class="absolute -top-20 -right-20 w-[280px] h-[280px] bg-[#9B84C2] rounded-[120px] opacity-40 -z-10"></div>
+     <div class="md:w-1/2 text-center md:text-right">
+      <h3 class="text-[20px] sm:text-[24px] font-semibold text-[#5B21B6]">Organize easily</h3>
+      <p class="mt-3 text-[14px] sm:text-[16px] text-gray-700 max-w-md mx-auto md:mx-0">Categorize and tag your notes effortlessly to find what you need instantly.</p>
+     </div>
+     <div class="md:w-1/2 mt-8 md:mt-0 flex justify-center md:justify-start">
+      <img src="https://storage.googleapis.com/a1aa/image/3d502902-c462-4412-39c7-ea9c6be0c3e8.jpg" alt="Screenshot showing note organization interface with tags and categories" class="rounded-lg shadow-md w-full max-w-[360px]" width="360" height="280"/>
+     </div>
+    </div>
+    <!-- Universal beauty -->
+    <div class="relative flex flex-col md:flex-row items-center md:items-start md:space-x-12">
+     <div aria-hidden="true" class="absolute -top-20 -left-20 w-[280px] h-[280px] bg-[#8DAF9B] rounded-[120px] opacity-40 -z-10"></div>
+     <div class="md:w-1/2 text-center md:text-left">
+      <h3 class="text-[20px] sm:text-[24px] font-semibold text-[#3B6B4F]">Universal beauty</h3>
+      <p class="mt-3 text-[14px] sm:text-[16px] text-gray-700 max-w-md mx-auto md:mx-0">Enjoy a clean, elegant design that looks great on any device or screen size.</p>
+     </div>
+     <div class="md:w-1/2 mt-8 md:mt-0 flex justify-center md:justify-end">
+      <img src="https://storage.googleapis.com/a1aa/image/06873345-4719-4c8f-4d53-b8dbfc7690dd.jpg" alt="Screenshot showing beautiful note interface on desktop and mobile" class="rounded-lg shadow-md w-full max-w-[360px]" width="360" height="280"/>
+     </div>
+    </div>
+    <!-- Private security -->
+    <div class="relative flex flex-col md:flex-row-reverse items-center md:items-start md:space-x-0 md:space-x-reverse md:space-x-12">
+     <div aria-hidden="true" class="absolute -top-20 -right-20 w-[280px] h-[280px] bg-[#E6C75A] rounded-[120px] opacity-40 -z-10"></div>
+     <div class="md:w-1/2 text-center md:text-right">
+      <h3 class="text-[20px] sm:text-[24px] font-semibold text-[#B27F00]">Private security</h3>
+      <p class="mt-3 text-[14px] sm:text-[16px] text-gray-700 max-w-md mx-auto md:mx-0">Your notes are encrypted and stored securely, so only you have access.</p>
+     </div>
+     <div class="md:w-1/2 mt-8 md:mt-0 flex justify-center md:justify-start">
+      <img src="https://storage.googleapis.com/a1aa/image/2bd50897-aef2-41d4-3543-28cb5015a7bc.jpg" alt="Screenshot showing security features with lock icon and encrypted notes" class="rounded-lg shadow-md w-full max-w-[360px]" width="360" height="280"/>
+     </div>
+    </div>
+   </section>
+   <!-- And so much more section -->
+   <section class="mt-28 max-w-5xl mx-auto px-4">
+    <h2 class="text-[22px] sm:text-[28px] md:text-[32px] font-semibold leading-tight text-center">And so much more</h2>
+    <p class="mt-3 text-[14px] sm:text-[16px] text-gray-600 text-center max-w-3xl mx-auto">Explore additional features like cloud sync, offline access, and customizable themes.</p>
+    <div class="mt-12 grid grid-cols-1 sm:grid-cols-2 gap-8 max-w-4xl mx-auto">
+     <div class="flex items-start space-x-4">
+      <i class="fas fa-cloud fa-lg text-blue-600 mt-1"></i>
+      <div>
+       <h3 class="font-semibold text-[16px] text-gray-900">Cloud sync</h3>
+       <p class="text-[14px] text-gray-700">Keep your notes updated across all your devices automatically.</p>
+      </div>
+     </div>
+     <div class="flex items-start space-x-4">
+      <i class="fas fa-wifi fa-lg text-green-600 mt-1"></i>
+      <div>
+       <h3 class="font-semibold text-[16px] text-gray-900">Offline access</h3>
+       <p class="text-[14px] text-gray-700">Access and edit your notes even without an internet connection.</p>
+      </div>
+     </div>
+     <div class="flex items-start space-x-4">
+      <i class="fas fa-paint-brush fa-lg text-purple-600 mt-1"></i>
+      <div>
+       <h3 class="font-semibold text-[16px] text-gray-900">Customizable themes</h3>
+       <p class="text-[14px] text-gray-700">Choose from light, dark, and other themes to suit your style.</p>
+      </div>
+     </div>
+     <div class="flex items-start space-x-4">
+      <i class="fas fa-search fa-lg text-red-600 mt-1"></i>
+      <div>
+       <h3 class="font-semibold text-[16px] text-gray-900">Search your notes</h3>
+       <p class="text-[14px] text-gray-700">Quickly find any note with powerful search functionality.</p>
+      </div>
+     </div>
+    </div>
+   </section>
+   <!-- Pricing section -->
+   <section class="mt-28 max-w-4xl mx-auto px-4">
+    <h2 class="text-[22px] sm:text-[28px] md:text-[32px] font-semibold leading-tight text-center">Price</h2>
+    <div class="mt-12 flex flex-col sm:flex-row justify-center gap-8">
+     <!-- Free Plan -->
+     <div class="border border-gray-300 rounded-lg p-8 flex-1 max-w-sm mx-auto">
+      <h3 class="text-xl font-semibold mb-4 text-center">Free</h3>
+      <ul class="space-y-2 text-gray-700 text-[14px]">
+       <li>Unlimited notes</li>
+       <li>Basic Markdown support</li>
+       <li>Sync on one device</li>
+       <li>Community support</li>
+      </ul>
+      <div class="mt-8 text-center">
+       <span class="text-2xl font-bold">$0</span>
+       <span class="text-sm text-gray-500">/ forever</span>
+      </div>
+     </div>
+     <!-- Bear Pro Plan -->
+     <div class="border border-gray-300 rounded-lg p-8 flex-1 max-w-sm mx-auto relative">
+      <div class="absolute top-0 right-0 bg-red-600 text-white text-xs font-semibold px-3 py-1 rounded-bl-lg">PRO</div>
+      <h3 class="text-xl font-semibold mb-4 text-center">Bear Pro</h3>
+      <ul class="space-y-2 text-gray-700 text-[14px]">
+       <li>All Free features</li>
+       <li>Advanced Markdown</li>
+       <li>Sync across all devices</li>
+       <li>Priority support</li>
+       <li>Custom themes</li>
+      </ul>
+      <div class="mt-8 text-center">
+       <span class="text-2xl font-bold line-through text-gray-400">$52.99</span>
+       <span class="text-2xl font-bold text-green-600 ml-2">$36.99</span>
+       <span class="text-sm text-gray-500">/ year</span>
+      </div>
+     </div>
+    </div>
+    <div class="mt-10 text-center">
+     <a href="#" class="inline-block bg-black text-white text-[14px] sm:text-[16px] font-semibold rounded-md px-8 py-3 hover:bg-gray-900 transition">Get it on iOS</a>
+    </div>
+   </section>
+   <!-- Footer -->
+   <footer class="mt-28 border-t border-gray-200 pt-16 pb-20 text-center max-w-3xl mx-auto px-4">
+    <p class="text-[14px] text-gray-600 max-w-xl mx-auto">Join the community of thousands who love Markdown Notes. Share tips, get support, and stay updated.</p>
+    <form method="POST" action="#" class="mt-8 flex max-w-md mx-auto">
+     <input type="email" name="email" placeholder="Enter your email" required class="flex-grow border border-gray-300 rounded-l-md px-4 py-3 text-[14px] focus:outline-none focus:ring-2 focus:ring-blue-500"/>
+     <button type="submit" class="bg-blue-600 text-white px-6 py-3 rounded-r-md font-semibold text-[14px] hover:bg-blue-700 transition">Subscribe</button>
+    </form>
+   </footer>
+   <!-- Bottom footer links -->
+   <div class="mt-20 border-t border-gray-200 py-10 text-center text-gray-500 text-[12px] space-y-2 max-w-md mx-auto">
+    <p>© 2024 Markdown Notes. All rights reserved.</p>
+    <nav class="flex justify-center space-x-6 text-[12px]">
+     <a href="#" class="hover:underline">Privacy Policy</a>
+     <a href="#" class="hover:underline">Terms of Service</a>
+     <a href="#" class="hover:underline">Contact</a>
+    </nav>
+   </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create new `markdown_notes.html` template with Bear-style design
- add `/markdown-notes` route to serve the marketing page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874770b0524833389b93bfbc73a0324