### PR TITLE
Enable running app.py as a script

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,3 +205,8 @@ def _register_cli(app: Flask) -> None:
 # --------------------------------------------------------------------------- #
 
 app = create_app()
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8080))
+    debug = os.getenv("FLASK_ENV") == "development"
+    app.run(host="0.0.0.0", port=port, debug=debug)


### PR DESCRIPTION
## Summary
- run the Flask app when executing app.py directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874e969fefc8333a8747e6a55e6c84a