### PR TITLE
Fix stats on index page

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -14,7 +14,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 from config import Config
-from utils import ensure_directory_exists
+from utils import ensure_directory_exists, get_rule_stats, get_activity_trend
 
 main = Blueprint("main", __name__)
 
@@ -24,7 +24,9 @@ def index():
     """Render the application home page."""
 
     try:
-        return render_template("index.html", charts={})
+        stats = get_rule_stats()
+        trend = get_activity_trend(days=30)
+        return render_template("index.html", stats=stats, charts={"rules": trend})
     except Exception as exc:
         current_app.logger.error("Index page error: %s", exc)
         abort(500)

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -2,6 +2,7 @@ import os
 import sys
 import types
 import json
+from datetime import datetime, timedelta
 
 # Ensure project root is on the path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -55,3 +56,31 @@ def test_generate_mermaid_code():
     edges = [{'edge_str': 'A --> B'}]
     result = generate_mermaid_code(nodes, edges)
     assert result.splitlines() == ['graph TD', 'A[Start]', 'B[End]', 'A --> B']
+
+def test_rule_stats_and_trend(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, 'DATA_DIR', tmp_path)
+    monkeypatch.setattr(Config, 'ACTIVITY_LOG', tmp_path / 'activity_log.json')
+    data = {
+        'rules': {
+            'r1': {},
+            'r2': {},
+        },
+        'activity_log': [
+            {'timestamp': (datetime.utcnow() - timedelta(days=1)).isoformat()},
+            {'timestamp': (datetime.utcnow() - timedelta(days=10)).isoformat()},
+            {'timestamp': (datetime.utcnow() - timedelta(days=40)).isoformat()},
+            {'timestamp': (datetime.utcnow() - timedelta(days=80)).isoformat()},
+        ],
+    }
+    (Config.ACTIVITY_LOG).write_text(json.dumps(data))
+
+    stats = utils.get_rule_stats()
+    assert stats['total_rules'] == 2
+    assert stats['last_7_days'] == 1
+    assert stats['last_30_days'] == 2
+    assert stats['last_90_days'] == 4
+
+    trend = utils.get_activity_trend(days=5)
+    assert len(trend) == 5
+    assert sum(d['count'] for d in trend) >= 1
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,7 +11,12 @@ from .rule_utils import (
     validate_hierarchy_data,
     build_hierarchy,
 )
-from .logging_utils import log_activity, ActivityLogEntry
+from .logging_utils import (
+    log_activity,
+    ActivityLogEntry,
+    get_rule_stats,
+    get_activity_trend,
+)
 from .core import (
     highlight_matches,
     get_snippet,
@@ -42,4 +47,6 @@ __all__ = [
     "add_missing_guids_if_needed",
     "get_file_metadata",
     "highlight_matches",
+    "get_rule_stats",
+    "get_activity_trend",
 ]

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -5,7 +5,7 @@ import dataclasses
 import json
 import os
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 from config import Config
 
@@ -46,3 +46,57 @@ def log_activity(action: str, rule_id: str | None = None, user: str | None = Non
             json.dump(data, f, indent=2)
     except Exception as exc:  # pragma: no cover - log failures shouldn't crash
         LOGGER.error("Failed to log activity: %s", exc)
+
+
+def get_rule_stats() -> dict:
+    """Return rule counts and recent activity totals."""
+    Config.ensure_data_dir()
+    try:
+        with open(Config.ACTIVITY_LOG, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        now = datetime.utcnow()
+        totals = {
+            "total_rules": len(data.get("rules", {})),
+            "last_7_days": 0,
+            "last_30_days": 0,
+            "last_90_days": 0,
+        }
+        for entry in data.get("activity_log", []):
+            try:
+                ts = datetime.fromisoformat(entry["timestamp"])
+            except Exception:
+                continue
+            if ts >= now - timedelta(days=7):
+                totals["last_7_days"] += 1
+            if ts >= now - timedelta(days=30):
+                totals["last_30_days"] += 1
+            if ts >= now - timedelta(days=90):
+                totals["last_90_days"] += 1
+        return totals
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        LOGGER.error("Failed to compute stats: %s", exc)
+        return {"total_rules": 0, "last_7_days": 0, "last_30_days": 0, "last_90_days": 0}
+
+
+def get_activity_trend(days: int = 30) -> list[dict]:
+    """Return daily activity counts for the past ``days`` days."""
+    Config.ensure_data_dir()
+    try:
+        with open(Config.ACTIVITY_LOG, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        now = datetime.utcnow()
+        start_date = now.date() - timedelta(days=days - 1)
+        counts = { (start_date + timedelta(days=i)).isoformat(): 0 for i in range(days) }
+        for entry in data.get("activity_log", []):
+            try:
+                ts = datetime.fromisoformat(entry["timestamp"]).date()
+            except Exception:
+                continue
+            if ts.isoformat() in counts:
+                counts[ts.isoformat()] += 1
+        return [
+            {"label": d, "count": counts[d]} for d in sorted(counts.keys())
+        ]
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        LOGGER.error("Trend calculation failed: %s", exc)
+        return []


### PR DESCRIPTION
## Summary
- add utils for rule stats and trends
- export new functions
- show stats on index page
- cover new helpers in tests

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6875125ce86083338751b5caab84aaf2