### PR TITLE
Fix analytics link on dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -101,7 +101,7 @@
       </a>
       <a href="{{ url_for('analytics_routes.get_stats') }}" class="quick-action">
         <i class="fa-solid fa-chart-line"></i>
-        Advanced analytics
+        View analytics
       </a>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- update the dashboard quick action text and ensure it links to the stats endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875194f616083339e970570bf164fab