### PR TITLE
Fix missing logo path

### DIFF
--- a/standalone_dashboard.html
+++ b/standalone_dashboard.html
@@ -582,7 +582,7 @@ visibility: hidden;
     <nav class="fixed top-0 w-full h-nav-h bg-white/90 dark:bg-bear-ink/90 backdrop-blur z-30">
       <div class="wrapper flex items-center justify-between h-full">
         <a href="#" class="flex items-center gap-2">
-          <img src="static/img/logo.png" class="h-6 w-auto" alt="Rules Central logo">
+          <img src="static/images/RulesCentralLogo.png" class="h-6 w-auto" alt="Rules Central logo">
           <span class="font-bold">Rules Central</span>
         </a>
         <ul class="hidden md:flex items-center gap-8">

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -1,7 +1,7 @@
 <nav class="fixed top-0 w-full h-nav-h bg-white/90 dark:bg-bear-ink/90 backdrop-blur z-30">
   <div class="wrapper flex items-center justify-between h-full">
     <a href="{{ url_for('main.index') }}" class="flex items-center gap-2">
-      <img src="{{ url_for('static', filename='img/logo.png') }}" class="h-6 w-auto" alt="Rules Central logo">
+      <img src="{{ url_for('static', filename='images/RulesCentralLogo.png') }}" class="h-6 w-auto" alt="Rules Central logo">
       <span class="font-bold">Rules Central</span>
     </a>
 


### PR DESCRIPTION
## Summary
- fix navbar and dashboard logo path to point to `static/images/RulesCentralLogo.png`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687522d26fd48333bf077289f6ae0659