### PR TITLE
Fix missing font references

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -58,97 +58,6 @@ article, aside, details, figcaption, figure, footer, header, hgroup, main, menu,
 a {
     cursor:pointer;
 }
-@font-face {
-    font-family: 'bearsans';
-    src: url('/fonts/bearsansui-regular-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansui-regular-webfont.woff') format('woff');
-    font-weight: 400;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'bearsans';
-    src: url('/fonts/bearsansui-italic-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansui-italic-webfont.woff') format('woff');
-    font-weight: 400;
-    font-style: italic;
-}
-
-@font-face {
-    font-family: 'bearsans';
-    src: url('/fonts/bearsansui-medium-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansui-medium-webfont.woff') format('woff');
-    font-weight: 500;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'bearsans';
-    src: url('/fonts/bearsansui-mediumitalic-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansui-mediumitalic-webfont.woff') format('woff');
-    font-weight: 500;
-    font-style: italic;
-}
-
-@font-face {
-    font-family: 'bearsans';
-    src: url('/fonts/bearsansui-bold-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansui-bold-webfont.woff') format('woff');
-    font-weight: 700;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'bearsans';
-    src: url('/fonts/bearsansui-bolditalic-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansui-bolditalic-webfont.woff') format('woff');
-    font-weight: 700;
-    font-style: italic;
-}
-
-@font-face {
-    font-family: 'bearsansheadline';
-    src: url('/fonts/bearsansuiheadline-bold-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansuiheadline-bold-webfont.woff') format('woff');
-    font-weight: 700;
-    font-style: normal;
-
-}
-
-@font-face {
-    font-family: 'bearsansheadline';
-    src: url('/fonts/bearsansuiheadline-bolditalic-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansuiheadline-bolditalic-webfont.woff') format('woff');
-    font-weight: 700;
-    font-style: italic;
-
-}
-
-@font-face {
-    font-family: 'bearsansheadline';
-    src: url('/fonts/bearsansuiheadline-medium-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansuiheadline-medium-webfont.woff') format('woff');
-    font-weight: 400;
-    font-style: normal;
-
-}
-
-@font-face {
-    font-family: 'bearsansheadline';
-    src: url('/fonts/bearsansuiheadline-mediumitalic-webfont.woff2') format('woff2'),
-         url('/fonts/bearsansuiheadline-mediumitalic-webfont.woff') format('woff');
-    font-weight: 400;
-    font-style: italic;
-
-}
-
-@font-face {
-    font-family: 'roboto-mono';
-    src: url('/fonts/Roboto-Mono-regular.woff2') format('woff2'),
-         url('/fonts/Roboto-Mono-regular.woff') format('woff');
-    font-weight: 400;
-    font-style: normal;
-}
 
 :root {
     --background-color: #fff;
@@ -158,9 +67,9 @@ a {
     --text-secondary-color: #888888;
     --text-tertiary-color: #d9d9d9;
     --accent-color: #DD4C4F;
-    --text-font: "bearsans";
-    --heading-font: "bearsansheadline";
-    --code-font: "roboto-mono";
+    --text-font: "Inter", sans-serif;
+    --heading-font: "Inter", sans-serif;
+    --code-font: monospace;
     --stroke-color: #D9D9D9;
 }
 


### PR DESCRIPTION
## Summary
- drop custom `@font-face` rules pointing to missing fonts
- switch text and heading fonts to use Inter

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687531cfd8448333a7387d6b72f744c7