### PR TITLE
Fix nav link for diagrams

### DIFF
--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -24,8 +24,8 @@
           </li>
           <li>
             <a class="nav-link px-4 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800" 
-               href="{{ url_for('diagrams.diagrams') }}"
-               {% if request.path == url_for('diagrams.diagrams') %}aria-current="page"{% endif %}>
+               href="{{ url_for('diagrams.diagrams_index') }}"
+               {% if request.path == url_for('diagrams.diagrams_index') %}aria-current="page"{% endif %}>
               Diagrams
             </a>
           </li>
@@ -124,9 +124,9 @@
           </a>
         </li>
         <li>
-          <a class="nav-link block px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800" 
-             href="{{ url_for('diagrams.diagrams') }}"
-             {% if request.path == url_for('diagrams.diagrams') %}aria-current="page"{% endif %}>
+          <a class="nav-link block px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+             href="{{ url_for('diagrams.diagrams_index') }}"
+             {% if request.path == url_for('diagrams.diagrams_index') %}aria-current="page"{% endif %}>
             Diagrams
           </a>
         </li>


### PR DESCRIPTION
## Summary
- update navbar to use `diagrams_index` endpoint

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68755ec8eefc833380346ef118d9d2c1