### PR TITLE
Implement Bear-inspired theme elements

### DIFF
--- a/static/css/critical.css
+++ b/static/css/critical.css
@@ -1,0 +1,18 @@
+@layer base {
+  @font-face {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 400;
+    src: url('/static/fonts/Inter-Regular.woff2') format('woff2');
+    font-display: swap;
+  }
+
+  html {
+    scroll-behavior: smooth;
+    text-size-adjust: 100%;
+  }
+  body {
+    @apply bg-paper text-ink antialiased;
+    text-rendering: optimizeLegibility;
+  }
+}

--- a/static/js/illustrations.js
+++ b/static/js/illustrations.js
@@ -1,0 +1,16 @@
+export function initBearAnimations() {
+  document.querySelectorAll('.bear-illustration-path').forEach(path => {
+    const length = path.getTotalLength();
+    path.style.strokeDasharray = length;
+    path.style.strokeDashoffset = length;
+
+    const observer = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        path.style.transition = 'stroke-dashoffset 800ms cubic-bezier(0.4, 0, 0.2, 1)';
+        path.style.strokeDashoffset = '0';
+      }
+    });
+
+    observer.observe(path.closest('svg'));
+  });
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,33 +8,19 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#DD4C4F',
-          500: '#DD4C4F',
-          600: '#DD4C4F',
-          700: '#c04244',
-          gradientStart: '#DD4C4F',
-          gradientEnd: '#FFC371'
+          50: '#FFF0F0',
+          100: '#FFD6D6',
+          200: '#FFB5B5',
+          300: '#FF7B7B',
+          400: '#E06B6B',
+          500: '#D45A5A',
+          ink: '#1F1F1F',
+          paper: '#F5F5F7'
         },
-        danger: {
-          gradientStart: '#ff6b6b',
-          gradientEnd: '#ee5a24'
-        },
-        'surface-white': '#FFFFFF',
-        'surface-shade': '#FAFAFA',
-        'ink-900': '#1C1C1E',
-        'ink-600': '#444448',
-        'ink-400': '#94949A',
-        'accent-red': '#FF3B30',
-        'accent-red-dark': '#FF453A',
-        status: {
-          active: '#22c55e',
-          draft: '#fbbf24',
-          archived: '#9ca3af'
-        },
-        background: {
-          darkStart: '#0f0f23',
-          darkMid: '#1a1a3e',
-          darkEnd: '#2d1b69'
+        ink: {
+          DEFAULT: 'rgba(31, 31, 31, 0.9)',
+          secondary: 'rgba(31, 31, 31, 0.7)',
+          tertiary: 'rgba(31, 31, 31, 0.5)'
         }
       },
       fontFamily: {
@@ -62,11 +48,20 @@ module.exports = {
         soft: '0 2px 8px rgb(0 0 0 / 0.08)',
         glow: '0 8px 32px rgba(0, 0, 0, 0.3)',
         pulse: '0 0 20px rgba(59, 130, 246, 0.3)',
-        card: '0 4px 12px rgba(0,0,0,0.04)'
+        card: '0 4px 12px rgba(0,0,0,0.04)',
+        'bear-card': '0 4px 24px -6px rgba(0, 0, 0, 0.08)',
+        'bear-button': '0 2px 0 rgba(0, 0, 0, 0.05) inset'
       },
       spacing: {
+        '0.5': '0.125rem',
+        '7.5': '1.875rem',
+        '15': '3.75rem',
         18: '4.5rem',
         22: '5.5rem'
+      },
+      fontSize: {
+        '2xs': ['0.6875rem', { lineHeight: '1rem' }],
+        '3xl': ['1.75rem', { lineHeight: '2.25rem', letterSpacing: '-0.02em' }]
       },
       animation: {
         float: 'float 3s ease-in-out infinite',
@@ -87,13 +82,30 @@ module.exports = {
   plugins: [
     require('@tailwindcss/forms'),
     require('@tailwindcss/typography'),
-    plugin(({ addUtilities }) => {
+    plugin(({ addUtilities, addComponents }) => {
       addUtilities({
         '.underline-squiggle': {
           background:
             "url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"160\" height=\"6\" viewBox=\"0 0 160 6\"><path fill=\"none\" stroke=\"%23DD4C4F\" stroke-width=\"3\" d=\"M0 3 Q20 6 40 3 T80 3 T120 3 T160 3\"/></svg>') repeat-x bottom/auto 6px",
           paddingBottom: '0.25rem',
         },
+      });
+      addComponents({
+        '.bear-illustration-path': {
+          strokeWidth: '1.5px',
+          strokeLinecap: 'round',
+          vectorEffect: 'non-scaling-stroke'
+        },
+        '.cta-primary': {
+          padding: '0.75rem 1.5rem',
+          borderRadius: '9999px',
+          backgroundColor: '#FF7B7B',
+          transition: 'all 200ms cubic-bezier(0.4, 0, 0.2, 1)',
+          '&:hover': {
+            transform: 'translateY(-1px)',
+            boxShadow: '0 4px 12px -2px rgba(255, 123, 123, 0.4)'
+          }
+        }
       });
     }),
   ],

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,24 +1,36 @@
 {# base.html — Bear-style skeleton template #}
-<!doctype html>
-<html lang="en" data-theme="bear" class="scroll-smooth">
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth antialiased">
   <head>
     <meta charset="utf-8">
     <title>{% block title %}Rules Central{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{% block description %}Centralized rules management system{% endblock description %}">
     
+    <meta name="theme-color" content="#F5F5F7">
+    <meta name="color-scheme" content="light dark">
+
     <!-- Preload critical resources -->
-    <link rel="preload" href="https://rsms.me/inter/inter.css" as="style" crossorigin>
-    <link rel="preload" href="{{ url_for('static', filename='css/output.css') }}" as="style">
+    <link rel="preload" href="{{ url_for('static', filename='fonts/Inter.var.woff2') }}" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="{{ url_for('static', filename='css/critical.css') }}" as="style">
     
     <!-- Favicon -->
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
     <link rel="apple-touch-icon" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
-    
-    <!-- Web fonts -->
-    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" crossorigin="anonymous">
+
+    <!-- Typography System -->
+    <style>
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 400 600;
+        font-display: swap;
+        src: url('{{ url_for('static', filename='fonts/Inter.var.woff2') }}') format('woff2');
+      }
+    </style>
     
     <!-- CSS -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/critical.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/output.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.processed.css') }}" media="print" onload="this.media='all'">
     
@@ -29,7 +41,8 @@
     {% block head %}{% endblock head %}
   </head>
 
-  <body class="flex flex-col min-h-screen bg-white dark:bg-bear-ink text-gray-800 dark:text-gray-100 antialiased">
+  <body class="bg-paper text-ink min-h-screen flex flex-col">
+    <div class="fixed inset-0 grid grid-cols-24 gap-1 pointer-events-none" style="background: repeating-linear-gradient(0deg, transparent, transparent 7px, #FF7B7B10 8px)"></div>
     <!-- Skip to content link for accessibility -->
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-bear-red focus:text-white focus:rounded">
       Skip to content
@@ -45,6 +58,7 @@
 
     <!-- Scripts -->
     <script src="{{ url_for('static', filename='js/theme.js') }}" type="module" async></script>
+    <script src="{{ url_for('static', filename='js/illustrations.js') }}" type="module" async></script>
     
     {% block scripts %}{% endblock scripts %}
     


### PR DESCRIPTION
## Summary
- update Tailwind palette and utilities
- add Bear component plugin entries
- include critical CSS and illustration animation script
- enhance base template with new theme meta and overlay

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687598c5d82483338393ab2638a3d663