### PR TITLE
Fix Inter variable font path

### DIFF
--- a/static/css/critical.css
+++ b/static/css/critical.css
@@ -13,7 +13,7 @@
     font-family: 'Inter';
     font-style: normal;
     font-weight: 100 900;
-    src: url('/static/fonts/Inter-Variable.woff2') format('woff2-variations');
+    src: url('/static/fonts/InterVariable.woff2') format('woff2-variations');
     font-display: swap;
   }
 


### PR DESCRIPTION
## Summary
- correct the filename in `critical.css` to load the variable Inter font

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68768ed37d1c83339b1ce0bc7113528d