### PR TITLE
Fix undefined now variable in templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,6 +96,7 @@ def create_app(**custom: Any) -> Flask:
     _register_blueprints(app)
     _register_error_handlers(app)
     _init_csrf(app)
+    _init_template_helpers(app)
     _register_cli(app)
 
     # If behind a reverse proxy / load balancer in prod
@@ -190,6 +191,17 @@ def _init_csrf(app: Flask) -> None:
         @app.context_processor
         def _inject_csrf() -> dict[str, Any]:  # noqa: D401
             return {"csrf_token": generate_csrf}
+
+
+def _init_template_helpers(app: Flask) -> None:
+    """Inject utility helpers into the Jinja environment."""
+    if not hasattr(app, "context_processor"):
+        return
+    from datetime import datetime, timezone
+
+    @app.context_processor
+    def _inject_now() -> dict[str, Any]:  # noqa: D401
+        return {"now": lambda: datetime.now(timezone.utc)}
 
 
 def _register_cli(app: Flask) -> None:


### PR DESCRIPTION
## Summary
- add a template helper that injects a `now()` function returning the current UTC time
- call the new helper from `create_app`

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6876b87d1ce88333b8dcb07a40ca6f99