### PR TITLE
Fix index template now variable

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -55,7 +55,7 @@
         <span>Key Metrics</span>
       </h2>
       <div class="text-sm text-slate-500 dark:text-slate-400">
-        Last updated: <span class="font-medium">{{ now.strftime('%b %d, %Y %I:%M %p') }}</span>
+        Last updated: <span class="font-medium">{{ now().strftime('%b %d, %Y %I:%M %p') }}</span>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- call `now()` in index template so timestamp renders correctly

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6876ba892f0483339f01ef64b45e9c9e