### PR TITLE
Update Bear-style input CSS

### DIFF
--- a/static/css/input.css
+++ b/static/css/input.css
@@ -1,7 +1,7 @@
 /**
- * Enhanced Tailwind Design System
- * ----------------------------------------------------------------------------
- * Modern, performance-optimized design system with improved theming and utilities
+ * Bear App Inspired Design System
+ * -----------------------------------------------------------------------------
+ * Next-level Tailwind setup bringing the warm Bear aesthetics to the project
  */
 
 @tailwind base;
@@ -13,11 +13,12 @@
    ========================================================================== */
 @layer base {
   :root {
-    /* Enhanced Color Tokens */
+    /* Bear Color Tokens */
     --color-accent: theme('colors.bear.red');
     --color-grey: theme('colors.bear.grey');
     --color-smoke: theme('colors.bear.smoke');
     --color-ink: theme('colors.bear.ink');
+    --color-highlight: theme('colors.primary.300');
     
     /* Theme-aware variables */
     --bg: theme('colors.primary.paper');
@@ -28,6 +29,7 @@
     --text-secondary: theme('colors.ink.secondary');
     --text-tertiary: theme('colors.ink.tertiary');
     --border: theme('colors.primary.200');
+    --border-highlight: var(--color-highlight);
     --focus-ring: theme('colors.primary.600');
   }
 
@@ -40,6 +42,7 @@
     --text-secondary: theme('colors.primary.200');
     --text-tertiary: theme('colors.primary.300');
     --border: theme('colors.primary.600');
+    --border-highlight: var(--color-highlight);
     --focus-ring: theme('colors.primary.400');
   }
 
@@ -51,6 +54,7 @@
     --text: #40322f;
     --text-secondary: #8a7b78;
     --border: #ffd4c7;
+    --border-highlight: var(--color-highlight);
     --focus-ring: #FF5E62;
   }
 
@@ -230,6 +234,11 @@
     @apply w-full px-4 py-2.5 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-colors;
     border: 1px solid var(--border);
     background-color: var(--bg-surface);
+  }
+
+  .bear-input {
+    @apply input shadow-bear-button placeholder:text-text-secondary;
+    border-color: var(--border-highlight);
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak `static/css/input.css` for a more polished Bear aesthetic
- add highlight variables and a `.bear-input` component
- keep dark/bear theme variables in sync

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6877c1e27ef4833381b1185edf277910