### PR TITLE
Improve dashboard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Rules Central is a Flask web application that helps you organize and visualize complex rule sets with ease.
 Upload diagrams, explore relationships and collaborate with your team in one streamlined environment.
 The interface ships with a **Bear-inspired theme** for a cohesive macOS look and feel.
+The dashboard UI now includes animated metrics cards and a handy back-to-top button for easier navigation.
 
 ## Quick Start
 1. Install Python requirements:
@@ -40,6 +41,7 @@ The interface ships with a **Bear-inspired theme** for a cohesive macOS look and
 - **API utility** for testing rules
 - **About** page with version info and documentation links
 - **Theme toggle** cycles through Bear, Dark and Light modes
+- **Enhanced styling** with gradients, glass cards and focus rings
 
 - **Contact page** for sending feedback
 

--- a/static/css/input.css
+++ b/static/css/input.css
@@ -93,6 +93,8 @@ a {
     --stroke-color: #dfe6e9;
     --card-shadow: 0 10px 30px -15px rgba(0,0,0,0.1);
     --transition-base: 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+    --background-gradient: linear-gradient(135deg, #FFF6F6 0%, #F8FBFF 100%);
+    --focus-ring: rgba(255, 120, 124, 0.5);
 }
 
 body {
@@ -103,6 +105,7 @@ body {
     position: relative;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     background-color: var(--background-color);
+    background-image: var(--background-gradient);
     font-weight: 400;
     letter-spacing: -0.01em;
 }
@@ -245,6 +248,13 @@ a:not(.link-button):hover:after {
     border: 1px solid rgba(0,0,0,0.03);
 }
 
+.glass-card {
+    backdrop-filter: blur(10px) saturate(180%);
+    background-color: rgba(255, 255, 255, 0.55);
+    border-radius: 1.5em;
+    border: 1px solid rgba(255, 255, 255, 0.125);
+}
+
 .card:hover {
     transform: translateY(-5px);
     box-shadow: 0 15px 40px -15px rgba(0,0,0,0.15);
@@ -264,6 +274,15 @@ a:not(.link-button):hover:after {
 .mb-3 { margin-bottom: 1.5em; }
 .mb-4 { margin-bottom: 2em; }
 
+@keyframes fade-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.fade-in {
+    animation: fade-in 0.6s ease forwards;
+}
+
 /* Sophisticated Dark Mode */
 @media (prefers-color-scheme: dark) {
     :root {
@@ -277,11 +296,18 @@ a:not(.link-button):hover:after {
         --accent-hover-color: #FF9094;
         --stroke-color: #444444;
         --card-shadow: 0 10px 30px -15px rgba(0,0,0,0.3);
+        --background-gradient: linear-gradient(135deg, #2a2a2a 0%, #1a1a1a 100%);
+        --focus-ring: rgba(255, 120, 124, 0.7);
     }
     
     .card {
         background-color: var(--background-secondary-color);
         border-color: rgba(255,255,255,0.03);
+    }
+
+    .glass-card {
+        background-color: rgba(37,37,37,0.55);
+        border-color: rgba(255,255,255,0.05);
     }
     
     a:not(.link-button):after {
@@ -295,6 +321,28 @@ input, textarea, button, select {
     font-size: inherit;
     line-height: inherit;
     color: inherit;
+}
+
+:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 3px;
+}
+
+::-webkit-scrollbar {
+    width: 10px;
+}
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+::-webkit-scrollbar-thumb {
+    background: var(--accent-color);
+    border-radius: 6px;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: var(--accent-hover-color);
+}
+body {
+    scrollbar-color: var(--accent-color) transparent;
 }
 
 ::selection {

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,7 @@
     </main>
 
     {% include 'partials/footer.html' %}
+    {% include 'partials/back_to_top.html' %}
 
     {% block scripts %}{% endblock scripts %}
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,13 +48,13 @@
 
         <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
             <!-- Total Rules Card -->
-            <div class="p-5 rounded-xl bg-background-secondary hover:bg-background-tertiary transition-colors">
+            <div class="p-5 rounded-xl bg-background-secondary hover:bg-background-tertiary transition-colors stats-card">
                 <div class="flex justify-between items-start">
                     <div>
                         <p class="text-sm text-text-secondary mb-1">Total Rules</p>
                         <p class="text-3xl font-bold text-text">1</p>
                     </div>
-                    <div class="p-2 rounded-lg bg-accent/10 text-accent">
+                    <div class="p-2 rounded-lg bg-accent/10 text-accent stats-icon">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                         </svg>
@@ -67,6 +67,24 @@
                         </svg>
                         +2.5% (7d)
                     </span>
+                </div>
+            </div>
+
+            <!-- Active Users Card -->
+            <div class="p-5 rounded-xl bg-background-secondary hover:bg-background-tertiary transition-colors stats-card">
+                <div class="flex justify-between items-start">
+                    <div>
+                        <p class="text-sm text-text-secondary mb-1">Active Users</p>
+                        <p class="text-3xl font-bold text-text">5</p>
+                    </div>
+                    <div class="p-2 rounded-lg bg-accent/10 text-accent stats-icon">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5V4H2v16h5m10 0V10m0 10l-4-4m4 4l4-4" />
+                        </svg>
+                    </div>
+                </div>
+                <div class="mt-3 flex items-center text-sm">
+                    <span class="text-emerald-500">+1 user today</span>
                 </div>
             </div>
 
@@ -106,4 +124,9 @@
         </div>
     </div>
 </section>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script defer src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
 {% endblock %}

--- a/templates/partials/back_to_top.html
+++ b/templates/partials/back_to_top.html
@@ -6,3 +6,29 @@
 >
   <i class="fas fa-arrow-up" aria-hidden="true"></i>
 </button>
+
+<style>
+  .back-to-top {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+
+  .back-to-top.show {
+    opacity: 1;
+    pointer-events: auto;
+  }
+</style>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('backToTop');
+    if (!btn) return;
+    window.addEventListener('scroll', () => {
+      btn.classList.toggle('show', window.scrollY > 300);
+    });
+  });
+</script>

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -1,4 +1,4 @@
-<nav class="fixed top-0 w-full h-16 bg-white/90 backdrop-blur-md border-b border-stroke-color z-50 transition-all duration-300">
+<nav class="fixed top-0 w-full h-16 bg-white/90 backdrop-blur-md border-b border-stroke-color z-50 transition-all duration-300" role="navigation" aria-label="Main navigation">
     <div class="wrapper flex items-center justify-between h-full">
         <!-- Logo/Brand -->
         <a href="{{ url_for('main.index') }}" class="flex items-center gap-2 group" aria-label="Rules Central Home">
@@ -13,6 +13,13 @@
         <!-- Desktop Navigation -->
         <div class="hidden md:flex items-center h-full">
             <ul class="flex items-center h-full gap-1">
+                <li class="h-full flex items-center">
+                    <a class="nav-link px-4 h-full flex items-center"
+                       href="{{ url_for('main.index') }}"
+                       {% if request.path == url_for('main.index') %}aria-current="page"{% endif %}>
+                        Dashboard
+                    </a>
+                </li>
                 <li class="h-full flex items-center">
                     <a class="nav-link px-4 h-full flex items-center"
                        href="{{ url_for('main.catalog') }}"
@@ -76,6 +83,13 @@
     <div id="mobile-menu" class="md:hidden hidden absolute top-16 left-0 right-0 bg-background-color shadow-lg border-t border-stroke-color transition-all duration-300 backdrop-blur-md">
         <div class="wrapper py-2">
             <ul class="flex flex-col gap-1">
+                <li>
+                    <a class="nav-link block px-4 py-3 rounded-lg"
+                       href="{{ url_for('main.index') }}"
+                       {% if request.path == url_for('main.index') %}aria-current="page"{% endif %}>
+                        Dashboard
+                    </a>
+                </li>
                 <li>
                     <a class="nav-link block px-4 py-3 rounded-lg"
                        href="{{ url_for('main.catalog') }}"


### PR DESCRIPTION
## Summary
- tweak navbar with dashboard link and ARIA label
- add global back-to-top button
- expand dashboard metrics and include dashboard script
- document new UI features
- enhance base CSS with gradient backgrounds, glass cards and focus ring
- update features list in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877cfb4d92c8333ba56aad92ac0e988