### PR TITLE
Improve styles and add sample metric card

### DIFF
--- a/static/css/input.css
+++ b/static/css/input.css
@@ -82,19 +82,25 @@ a {
 
 /* Bear-Inspired Typography & Colors */
 :root {
-    --background-color: #ffffff;
-    --background-secondary-color: #f8f9fa;
+    --text-primary: #1A1A1A;
+    --text-secondary: #4B5563;
+    --background: #FFFFFF;
+    --background-secondary: #F9FAFB;
+    --accent: #3B82F6;
+    --accent-hover: #2563EB;
+    --background-color: var(--background);
+    --background-secondary-color: var(--background-secondary);
     --background-tertiary-color: #e9ecef;
-    --text-color: #2d3436;
-    --text-secondary-color: #636e72;
+    --text-color: var(--text-primary);
+    --text-secondary-color: var(--text-secondary);
     --text-tertiary-color: #b2bec3;
-    --accent-color: #FF787C;
-    --accent-hover-color: #FF5A5F;
+    --accent-color: var(--accent);
+    --accent-hover-color: var(--accent-hover);
     --stroke-color: #dfe6e9;
     --card-shadow: 0 10px 30px -15px rgba(0,0,0,0.1);
     --transition-base: 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
     --background-gradient: linear-gradient(135deg, #FFF6F6 0%, #F8FBFF 100%);
-    --focus-ring: rgba(255, 120, 124, 0.5);
+    --focus-ring: rgba(59, 130, 246, 0.5);
 }
 
 body {
@@ -181,7 +187,7 @@ a:not(.link-button):after {
     left: 0;
     width: 0;
     height: 1px;
-    background-color: var(--accent-color);
+    background-color: var(--accent);
     transition: width var(--transition-base);
 }
 
@@ -220,7 +226,8 @@ a:not(.link-button):hover:after {
     text-align: center;
     border-radius: 100px;
     font-weight: 500;
-    transition: all var(--transition-base);
+    transition: all 0.2s ease;
+    transform: translateY(0);
     border: none;
     box-shadow: 0 4px 6px rgba(0,0,0,0.05);
 }
@@ -229,7 +236,7 @@ a:not(.link-button):hover:after {
     background: var(--accent-hover-color);
     color: white;
     transform: translateY(-1px);
-    box-shadow: 0 6px 12px rgba(0,0,0,0.1);
+    box-shadow: 0 4px 6px rgba(59, 130, 246, 0.2);
 }
 
 .link-button:active {
@@ -239,12 +246,12 @@ a:not(.link-button):hover:after {
 
 /* Premium Card Styling */
 .card {
-    background-color: white;
-    border-radius: 1.5em;
-    box-shadow: var(--card-shadow);
-    padding: 3em;
+    background: var(--background);
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    padding: 1.5rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
     margin-bottom: 3em;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
     border: 1px solid rgba(0,0,0,0.03);
 }
 
@@ -256,8 +263,8 @@ a:not(.link-button):hover:after {
 }
 
 .card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 40px -15px rgba(0,0,0,0.15);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
 }
 
 /* Subtle Utility Classes */
@@ -288,11 +295,11 @@ a:not(.link-button):hover:after {
     position: relative;
     color: var(--text-color);
     font-weight: 500;
-    transition: color 0.2s ease;
+    transition: color 0.2s ease, background 0.2s ease;
 }
 
 .nav-link:hover {
-    color: var(--accent-color);
+    color: var(--accent);
 }
 
 .nav-link::after {
@@ -344,6 +351,22 @@ a:not(.link-button):hover:after {
     pointer-events: auto;
 }
 
+/* Skeleton loading */
+.skeleton-loader {
+    animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+.skeleton-line {
+    background-color: var(--background-secondary);
+    border-radius: 4px;
+}
+
+@keyframes skeleton-pulse {
+    0% { opacity: 0.6; }
+    50% { opacity: 1; }
+    100% { opacity: 0.6; }
+}
+
 /* Stats card polish */
 .stats-card {
     transition: background-color 0.3s ease, transform 0.3s ease;
@@ -360,18 +383,22 @@ a:not(.link-button):hover:after {
 /* Sophisticated Dark Mode */
 @media (prefers-color-scheme: dark) {
     :root {
-        --background-color: #1A1A1A;
-        --background-secondary-color: #252525;
+        --text-primary: #F3F4F6;
+        --text-secondary: #9CA3AF;
+        --background: #111827;
+        --background-secondary: #1F2937;
+        --background-color: var(--background);
+        --background-secondary-color: var(--background-secondary);
         --background-tertiary-color: #333333;
-        --text-color: #F0F0F0;
-        --text-secondary-color: #AAAAAA;
+        --text-color: var(--text-primary);
+        --text-secondary-color: var(--text-secondary);
         --text-tertiary-color: #666666;
-        --accent-color: #FF787C;
-        --accent-hover-color: #FF9094;
+        --accent-color: var(--accent);
+        --accent-hover-color: var(--accent-hover);
         --stroke-color: #444444;
         --card-shadow: 0 10px 30px -15px rgba(0,0,0,0.3);
         --background-gradient: linear-gradient(135deg, #2a2a2a 0%, #1a1a1a 100%);
-        --focus-ring: rgba(255, 120, 124, 0.7);
+        --focus-ring: rgba(59, 130, 246, 0.7);
     }
     
     .card {

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,27 +47,23 @@
         </div>
 
         <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
-            <!-- Total Rules Card -->
-            <div class="p-5 rounded-xl bg-background-secondary hover:bg-background-tertiary transition-colors stats-card">
-                <div class="flex justify-between items-start">
-                    <div>
-                        <p class="text-sm text-text-secondary mb-1">Total Rules</p>
-                        <p class="text-3xl font-bold text-text">1</p>
-                    </div>
-                    <div class="p-2 rounded-lg bg-accent/10 text-accent stats-icon">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                        </svg>
-                    </div>
+            <!-- Example improved metric card -->
+            <div class="metric-card">
+              <div class="metric-header flex justify-between items-start">
+                <p class="metric-label text-sm text-text-secondary">Total Rules</p>
+                <div class="metric-icon p-2 rounded-lg bg-accent/10 text-accent">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
                 </div>
-                <div class="mt-3 flex items-center text-sm">
-                    <span class="text-emerald-500">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="inline w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
-                        </svg>
-                        +2.5% (7d)
-                    </span>
-                </div>
+              </div>
+              <p class="metric-value text-3xl font-bold text-text mt-2">1</p>
+              <div class="metric-trend positive flex items-center text-sm mt-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="inline w-4 h-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                <span class="text-emerald-500 ml-1">+2.5% (7d)</span>
+              </div>
             </div>
 
             <!-- Active Users Card -->
@@ -89,6 +85,11 @@
             </div>
 
             <!-- Additional metric cards would follow the same pattern -->
+            <!-- Skeleton loader example -->
+            <div class="skeleton-loader mt-4">
+              <div class="skeleton-line h-8 w-3/4"></div>
+              <div class="skeleton-line h-4 w-full mt-2"></div>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- update CSS variables for clearer colors
- tweak card, nav link and button styles
- add skeleton loader styling
- showcase improved metric card on index page

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6877ea64a0b8833384144133dc4fb698