### PR TITLE
Fix outdated routes in templates

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -6,7 +6,7 @@
 <section class="u-section py-12">
 
   <!-- Search bar -->
-  <form action="{{ url_for('routes.search') }}" method="get" class="flex flex-col sm:flex-row gap-3">
+  <form action="{{ url_for('main.search') }}" method="get" class="flex flex-col sm:flex-row gap-3">
     <div class="relative flex-1">
       <span class="absolute inset-y-0 left-3 flex items-center pointer-events-none text-slate-400">
         <!-- search icon -->
@@ -55,7 +55,7 @@
       <ul class="divide-y divide-white/10 rounded-xl overflow-hidden card--glass glassmorphism">
         {% for item in results|default([]) %}
           <li class="py-4 px-4 hover:bg-white/5 transition group">
-            <a href="{{ url_for('routes.rule_detail', id=item.id) }}"
+            <a href="#"
                class="text-primary-400 group-hover:text-primary-300 text-lg font-medium">{{ item.name }}</a>
             {% if item.description %}
               <p class="mt-1 text-slate-400 text-sm line-clamp-2">{{ item.description }}</p>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -147,15 +147,15 @@
     <div class="mt-12 text-center">
       <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">Need help uploading?</h3>
       <div class="flex flex-wrap justify-center gap-4">
-        <a href="{{ url_for('routes.docs', page='uploading-diagrams') }}" 
+        <a href="{{ url_for('routes.full_help') }}#uploading"
            class="text-sm text-primary-600 dark:text-primary-400 hover:underline">
           <i class="fas fa-book mr-2"></i> Documentation
         </a>
-        <a href="{{ url_for('routes.support') }}" 
+        <a href="{{ url_for('collab.faq_page') }}"
            class="text-sm text-primary-600 dark:text-primary-400 hover:underline">
           <i class="fas fa-question-circle mr-2"></i> Support
         </a>
-        <a href="{{ url_for('routes.examples') }}" 
+        <a href="{{ url_for('static', filename='js/sample_data/example.json') }}"
            class="text-sm text-primary-600 dark:text-primary-400 hover:underline">
           <i class="fas fa-file-image mr-2"></i> Example Files
         </a>


### PR DESCRIPTION
## Summary
- update search form route
- point docs/support/example links to valid locations
- remove missing rule detail link

## Testing
- `npm run build:css`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6878f1b783688333a4fecc088c0da4a7