### PR TITLE
Refine theme loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It consolidates diagrams, rule definitions and statistics into a single dashboar
 - **Search** and explore stored rules
 - **API utility** for testing rules
 - **About** page with version info and documentation links
-- **Theme toggle** cycles through Bear, Dark and Light modes
+- **Theme toggle** cycles through Bear, Dark, Light and High Contrast modes
 - **High contrast** option for improved accessibility
 - **Enhanced styling** with gradients, glass cards and focus rings
 - **First-time user tour** with contextual tips

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -7,7 +7,7 @@
  * choice is stored.
  */
 
-const STORAGE_KEY = 'theme';
+const STORAGE_KEY = 'rc-theme';
 const THEMES = ['bear', 'dark', 'light', 'contrast'];
 const systemDark = window.matchMedia('(prefers-color-scheme: dark)');
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,14 +53,14 @@
       d.dataset.theme = t;
     }
 
-    var t = localStorage.getItem(STORAGE_KEY);
-    if (!t || t === 'system') {
+    var t = localStorage.getItem(STORAGE_KEY) || 'bear';
+    if (t === 'system') {
       t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
     apply(t);
 
-    // Watch system changes if user is in 'system' mode
-    if (!localStorage.getItem(STORAGE_KEY) || localStorage.getItem(STORAGE_KEY) === 'system') {
+    // Watch system changes if user selected 'system'
+    if (localStorage.getItem(STORAGE_KEY) === 'system') {
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
         apply(e.matches ? 'dark' : 'light');
       });


### PR DESCRIPTION
## Summary
- sync theme.js storage key with base layout
- default to the Bear theme when no preference is saved
- document all four theme options in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687990cd4c808333a9f9d199fb451532