### PR TITLE
Add route definitions for all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ Recommended production stack:
 └── tests/                # Test suite
 ```
 
+## Routes
+
+Key page endpoints:
+
+- `/catalog` – browse the diagram catalog
+- `/api-test` – API test utility
+- `/rules-extraction` – FormWorks extraction tool
+- `/markdown-notes` – markdown notes demo
+- `/get-started` – quick start guide
+- `/hierarchy_viewer/<root>/<file>` – hierarchy viewer
+- `/dashboard` – dashboard alias
+- `/home` – marketing homepage
+- `/rule/<id>` – rule details
+
 ## Documentation
 
 - Interactive help: Press `Shift+/` in-app

--- a/all_routes.py
+++ b/all_routes.py
@@ -566,5 +566,74 @@ def view_diagram():
         abort(500, "Error loading diagram viewer")
 
 
+# ------------------------------------------------------------
+# Additional page routes
+# ------------------------------------------------------------
+
+
+@routes_bp.route("/catalog")
+def catalog():
+    """Browse available diagrams."""
+    return render_template("catalog.html", help_available=True)
+
+
+@routes_bp.route("/api-test")
+def api_test_page():
+    """Interactive API test utility."""
+    return render_template("api_test_utility.html", help_available=True)
+
+
+@routes_bp.route("/rules-extraction")
+def rules_extraction_page():
+    """FormWorks rules extraction tool."""
+    return render_template("rules_extraction_utility.html", help_available=True)
+
+
+@routes_bp.route("/markdown-notes")
+def markdown_notes_page():
+    """Demo page for Markdown notes."""
+    return render_template("markdown_notes.html")
+
+
+@routes_bp.route("/get-started")
+def get_started_page():
+    """Quick start guide."""
+    return render_template("get_started.html")
+
+
+@routes_bp.route("/hierarchy_viewer/<root_name>/<diagram_name>")
+def hierarchy_viewer_page(root_name, diagram_name):
+    """Display the hierarchy viewer for a diagram."""
+    return render_template(
+        "hierarchy_viewer.html",
+        root_name=secure_filename(root_name),
+        diagram_name=secure_filename(diagram_name),
+    )
+
+
+@routes_bp.route("/dashboard")
+def dashboard_page():
+    """Alias route for the dashboard."""
+    return render_template("dashboard.html")
+
+
+@routes_bp.route("/home")
+def home_page():
+    """Marketing home page."""
+    return render_template("home.html")
+
+
+@routes_bp.route("/rule/<int:rule_id>")
+def rule_detail(rule_id: int):
+    """Show details for a specific rule."""
+    return render_template("rule_detail.html", rule={"id": rule_id}, tree_view="")
+
+
+@routes_bp.route("/rule/<int:rule_id>/tab/<tab>")
+def rule_tab(rule_id: int, tab: str):
+    """Return placeholder tab content for rule detail view."""
+    return f"<p>{tab} tab for rule {rule_id}</p>"
+
+
 
 

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -231,6 +231,21 @@
         {% include 'partials/docs_code_block.html' %}
       </section>
 
+      <!-- Routes Section -->
+      <section id="routes" class="docs-section mb-12">
+        <h2 class="text-2xl font-bold text-white mb-3">Routes</h2>
+        <p class="text-gray-200 mb-4">
+          Key pages and their URLs.
+        </p>
+        <ul class="list-disc list-inside text-gray-200 space-y-1">
+          <li><code>/catalog</code> – browse available diagrams</li>
+          <li><code>/api-test</code> – API test utility</li>
+          <li><code>/rules-extraction</code> – extraction tool</li>
+          <li><code>/markdown-notes</code> – notes demo</li>
+          <li><code>/get-started</code> – quick start guide</li>
+        </ul>
+      </section>
+
       <!-- Continue with other sections using similar enhanced patterns... -->
       <!-- I'll show a few more key sections with improvements -->
 


### PR DESCRIPTION
## Summary
- expose catalog, API test, rules extraction and other pages
- document available routes in README and docs

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687ba09075c083338af28d4e72bf6e9f