### PR TITLE
Improve search page accessibility

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -118,7 +118,7 @@
     </svg>
   {% endset %}
 
-  <div class="rc-metrics-grid">
+  <div class="rc-metrics-grid" aria-live="polite" aria-atomic="true">
     {{ mcard('Total Rules',
              stats.total_rules if stats and 'total_rules' in stats else 0,
              'rc-accent-primary',
@@ -162,9 +162,9 @@
           Rule Change Trends
         </h2>
         <div class="rc-toggle-pill" role="group" aria-label="Select time range for trend chart">
-          <button data-range="30d" class="rc-toggle active" type="button">30D</button>
-          <button data-range="90d" class="rc-toggle" type="button">90D</button>
-          <button data-range="1y"  class="rc-toggle" type="button">1Y</button>
+          <button data-range="30d" class="rc-toggle active" type="button" aria-pressed="true">30D</button>
+          <button data-range="90d" class="rc-toggle" type="button" aria-pressed="false">90D</button>
+          <button data-range="1y"  class="rc-toggle" type="button" aria-pressed="false">1Y</button>
         </div>
       </div>
       <div class="rc-chart-wrap">
@@ -350,8 +350,12 @@
 
       document.querySelectorAll('.rc-toggle-pill .rc-toggle').forEach(btn=>{
         btn.addEventListener('click',()=>{
-          document.querySelectorAll('.rc-toggle-pill .rc-toggle').forEach(b=>b.classList.remove('active'));
+          document.querySelectorAll('.rc-toggle-pill .rc-toggle').forEach(b=>{
+            b.classList.remove('active');
+            b.setAttribute('aria-pressed','false');
+          });
           btn.classList.add('active');
+          btn.setAttribute('aria-pressed','true');
           const range=btn.dataset.range;
           // TODO: fetch new dataset for selected range; update chart.data then chart.update()
           chart.update();

--- a/templates/search.html
+++ b/templates/search.html
@@ -78,7 +78,7 @@
    `results` iterable expected from view. Each item can be:
      {title, name, rule_name, url, description, snippet, type, status, last_updated}
    ========================================================= #}
-<section class="wrapper rc-container pb-32 rc-search-results">
+<section id="search-results" class="wrapper rc-container pb-32 rc-search-results" role="region" aria-live="polite" aria-busy="false">
   {% if q %}
     <header class="mb-6 flex items-center justify-between">
       <div>
@@ -92,7 +92,7 @@
         {% endif %}
       </div>
       {% if results is defined and results %}
-        <button type="button" class="rc-search-export btn-secondary rc-cta">
+        <button type="button" class="rc-search-export btn-secondary rc-cta" aria-busy="false">
           <svg class="rc-search-export-icon" aria-hidden="true" viewBox="0 0 24 24">
             <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>
           </svg>
@@ -258,7 +258,7 @@
       searchClear.addEventListener('click', () => {
         searchInput.value = '';
         searchInput.focus();
-        searchClear.style.display = 'none';
+        searchClear.hidden = true;
         searchForm.submit();
       });
     }
@@ -267,12 +267,12 @@
     if (searchInput) {
       searchInput.addEventListener('input', () => {
         if (searchClear) {
-          searchClear.style.display = searchInput.value ? 'block' : 'none';
+          searchClear.hidden = !searchInput.value;
         }
       });
       // Initialize clear button state
       if (searchClear) {
-        searchClear.style.display = searchInput.value ? 'block' : 'none';
+        searchClear.hidden = !searchInput.value;
       }
     }
 
@@ -287,6 +287,7 @@
     if (exportBtn) {
       exportBtn.addEventListener('click', async () => {
         exportBtn.disabled = true;
+        exportBtn.setAttribute('aria-busy', 'true');
         exportBtn.innerHTML = `
           <svg class="animate-spin h-4 w-4" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -323,6 +324,7 @@
           alert('Failed to export results. Please try again.');
         } finally {
           exportBtn.disabled = false;
+          exportBtn.setAttribute('aria-busy', 'false');
           exportBtn.innerHTML = `
             <svg class="rc-search-export-icon" aria-hidden="true" viewBox="0 0 24 24">
               <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>


### PR DESCRIPTION
## Summary
- make search results a live region
- expose export button busy state
- hide clear search button using hidden property

## Testing
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_687be4a33fb483339b1d02d2d0ba58cf