### PR TITLE
Improve contribution docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,29 @@
 **Commit Messages**
 - Keep under 50 chars for title
 - Use present tense ("Add feature" not "Added feature")
-- Include brief details in body when needed
+- Begin with a short area prefix (`docs:`, `feat:`, `fix:`)
+- Include brief details in body when helpful
+
+**Branch Names**
+- Use `topic/short-description` format
+- Avoid working directly on `main`
 
 **Pull Requests**
 - Title: Summarize change
 - Description:
   - List key changes
   - Include test results (`pytest -v` output)
+  - Include screenshot for UI updates
   - Note any migrations needed
   - Mention docs/README updates
+  - Link relevant issues
 
 **Testing**
 - Run `pytest -v` on Python changes
 - Verify full functionality after changes
 - Check cross-browser compatibility for frontend
+- Run `npm test` if JavaScript tests are present
+- Ensure linting passes
 
 **Frontend Builds**
 - Run `npm run build:css` when:
@@ -30,6 +39,7 @@
   3. Relevant docstrings
 - Keep language clear and concise
 - Include examples for complex features
+- Document new features the same day they're merged
 
 **Workflow**
 1. Make changes

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ Key page endpoints:
 - API reference: `/api-docs`
 - Contributor guide: [AGENTS.md](AGENTS.md)
 
+## Contributing
+
+Follow these basics when contributing:
+
+- Use descriptive commit titles under 50 characters
+- Create topic branches instead of pushing to `main`
+- Run `pytest -v` and `npm run build:css` before opening a PR
+- Keep docs updated across README and the site
+- See [AGENTS.md](AGENTS.md) for the full checklist
+
 ## License
 
 MIT License - See [LICENSE](LICENSE) for details.

--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ Opinionated but lightweight Flask application factory with:
 * Structured JSON error responses
 * Production-grade logging to file + console
 * Click commands for shell context & DB bootstrap
+
+For developer workflow and contribution rules, see `AGENTS.md`.
 """
 
 from __future__ import annotations

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -232,6 +232,23 @@
         </div>
       </section>
 
+      <!-- Contributing Section -->
+      <section id="contributing" class="docs-section mb-12">
+        <h2 class="text-2xl font-bold text-white mb-3">Contributing</h2>
+        <p class="text-gray-200 mb-4">
+          Keep the project stable by following a few rules:
+        </p>
+        <ul class="list-disc list-inside text-gray-200 space-y-1">
+          <li>Use concise commit titles under 50 characters</li>
+          <li>Create topic branches instead of committing to <code>main</code></li>
+          <li>Run <code>pytest -v</code> and <code>npm run build:css</code> before PRs</li>
+          <li>Update documentation alongside your code</li>
+        </ul>
+        <p class="text-gray-200 mt-4">
+          See <a href="/AGENTS.md" class="text-primary-400 hover:text-primary-300">AGENTS.md</a> for the full checklist.
+        </p>
+      </section>
+
       <!-- API Section -->
       <section id="api" class="docs-section mb-12">
         <div class="flex items-center gap-3 mb-6">


### PR DESCRIPTION
## Summary
- clarify agent guidelines
- add contributing section to README
- mention AGENTS in app module
- document contribution workflow in site docs

## Testing
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_687bf261b610833386b6aee1d7544387