### PR TITLE
Fix missing DOM IDs in templates

### DIFF
--- a/templates/api_test_utility.html
+++ b/templates/api_test_utility.html
@@ -175,6 +175,13 @@
             </button>
           </div>
         </form>
+<section id="result-section" class="hidden mt-6 rounded border border-surface-3 bg-surface-1 p-4">
+  <header class="flex items-center justify-between mb-2">
+    <h3 class="text-sm font-semibold text-text-secondary">Response</h3>
+    <button id="copyButton" class="btn btn-secondary text-xs px-2 py-1" aria-label="Copy to clipboard">Copy</button>
+  </header>
+  <pre id="result-message" class="whitespace-pre-wrap text-xs leading-relaxed overflow-x-auto"></pre>
+</section>
       </div>
 
       <!-- Request Headers Section -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -110,12 +110,16 @@
 <body class="bg-background text-text min-h-screen flex flex-col">
   <!-- Skip to content -->
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div id="scroll-progress" class="h-1 bg-primary/50 fixed top-0 left-0 w-0 z-50"></div>
   {% block body_start %}{% endblock body_start %}
 
   {# ================= NAVIGATION ================= #}
   <nav id="rc-nav" class="rc-nav" role="navigation" aria-label="Main navigation">
     <div class="rc-nav-inner rc-container">
       {# Brand #}
+      <button id="mobile-menu-btn" type="button" class="btn btn-ghost p-2 md:hidden" aria-label="Toggle menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="1.5"><use href="#icon-bars-3"/></svg>
+      </button>
       <a href="{{ url_for('main.index') }}" class="rc-brand" aria-label="Rules Central Home">
         <img src="{{ url_for('static', filename='images/RulesCentralLogo.png') }}"
              alt=""
@@ -182,6 +186,10 @@
         {% endif %}
 
         {# Theme Toggle #}
+        <button id="helpButton" class="btn btn-ghost flex items-center gap-1" type="button" aria-haspopup="dialog" aria-controls="quickHelpModal">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5"><use href="#icon-question-mark-circle"/></svg>
+          <span class="sr-only">Quick Help</span>
+        </button>
         <button id="theme-toggle" class="rc-theme-toggle" aria-label="Toggle theme">
           <svg class="rc-theme-ico" viewBox="0 0 24 24" aria-hidden="true">
             <circle cx="12" cy="12" r="6" class="rc-theme-sun" />
@@ -223,6 +231,12 @@
       </div>
     </div>
   </nav>
+<nav id="mobile-menu" class="md:hidden hidden flex flex-col gap-1 bg-surface-1 border-t border-surface-3 px-4 py-3">
+  <a href="{{ url_for(main.index) }}" class="link py-1">Dashboard</a>
+  <a href="{{ url_for(main.catalog) }}" class="link py-1">Catalog</a>
+  <a href="{{ url_for(hierarchy.index) }}" class="link py-1">Hierarchy</a>
+  <a href="{{ url_for(main.docs) }}" class="link py-1">Docs</a>
+</nav>
 
   {# ================= MAIN CONTENT ================= #}
   <main id="main-content">
@@ -319,6 +333,25 @@
   {# ================= SCRIPTS ================= #}
   {% include 'partials/feedback_widget.html' %}
   {% block body_end %}{% endblock body_end %}
+<div id="quickHelpModal" class="fixed inset-0 z-50 hidden items-center justify-center bg-black/40 backdrop-blur-sm">
+  <div class="bg-surface-1 w-full max-w-md mx-4 rounded-lg shadow-lg">
+    <header class="flex items-center justify-between px-4 py-3 border-b border-surface-3">
+      <h2 class="text-base font-semibold">Quick Help</h2>
+      <button id="closeHelpModal" class="btn btn-ghost p-1" aria-label="Close help dialog">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5"><use href="#icon-x-mark"/></svg>
+      </button>
+    </header>
+    <div class="p-4 space-y-3 text-sm leading-relaxed">
+      <p>Welcome to Rules Central! Here are a few common shortcuts:</p>
+      <ul class="list-disc list-inside space-y-1">
+        <li><kbd class="kbd">/</kbd> to focus the global search</li>
+        <li><kbd class="kbd">?</kbd> anywhere to reopen this help</li>
+        <li><kbd class="kbd">⌘</kbd><kbd>←/→</kbd> to collapse / expand all nodes</li>
+      </ul>
+      <p class="pt-2 text-text-tertiary">Need deeper docs? Visit <a href="{{ url_for(main.docs) }}" class="link">Documentation</a>.</p>
+    </div>
+  </div>
+</div>
 
   {# SVG Sprite for icons #}
   <svg aria-hidden="true" style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg">
@@ -349,6 +382,15 @@
     <script defer src="{{ url_for('static', filename='js/theme.js') }}"></script>
     <script defer src="{{ url_for('static', filename='js/navigation.js') }}"></script>
     <script defer src="{{ url_for('static', filename='js/user_tour.js') }}"></script>
+<div id="notificationToast" class="fixed bottom-4 left-1/2 -translate-x-1/2 max-w-xs w-full pointer-events-none z-50 hidden">
+  <div class="flex items-start gap-2 rounded border border-surface-3 bg-surface-1 px-4 py-3 shadow-lg">
+    <svg class="w-5 h-5 shrink-0 text-primary" fill="none" stroke="currentColor" stroke-width="1.5"><use href="#icon-bell"/></svg>
+    <p data-toast-msg class="text-sm leading-snug flex-1"></p>
+    <button type="button" class="btn btn-ghost p-1 -m-1" aria-label="Dismiss toast">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5"><use href="#icon-x-mark"/></svg>
+    </button>
+  </div>
+</div>
   {% endblock scripts %}
 </body>
 </html>

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -256,7 +256,7 @@
 </div>
 
 
-<div id="rc-catalog-list" class="rc-catalog-list" hidden>
+<div id="catalogContainer" class="rc-catalog-list" hidden>
   {% if diagrams %}
     {% for d in diagrams %}
       {% set d_id    = d.id    if d is mapping and 'id' in d else loop.index %}
@@ -438,7 +438,7 @@
     const gridBtn       = document.getElementById('rc-catalog-view-grid');
     const listBtn       = document.getElementById('rc-catalog-view-list');
     const gridWrap      = document.getElementById('rc-catalog-grid');
-    const listWrap      = document.getElementById('rc-catalog-list');
+    const listWrap      = document.getElementById('catalogContainer');
     const sortSelect    = document.getElementById('rc-cat-sort');
     const filterOpenBtn = document.getElementById('rc-cat-filter-open');
     const filterDrawer  = document.getElementById('rc-cat-filters');

--- a/templates/hierarchy_viewer.html
+++ b/templates/hierarchy_viewer.html
@@ -26,18 +26,18 @@
           <h2 class="text-xl font-semibold text-text">Rule Tree</h2>
           <span class="text-sm text-text-secondary" id="node-count">0 nodes</span>
         </div>
-        <div class="mb-4">
-          <div class="input focus-ring">
-            {{ input('tree-search', 'text', 'Search nodes...') }}
-          </div>
-        </div>
-        <div class="flex items-center justify-between text-sm text-text-secondary mb-4">
-          <span>0 / 0</span>
-          <div class="flex gap-2">
-            {{ button('Expand', variant='secondary', type='button', classes='text-xs px-3 py-1') }}
-            {{ button('Collapse', variant='secondary', type='button', classes='text-xs px-3 py-1') }}
-          </div>
-        </div>
+        <div class="flex flex-wrap items-center gap-3 mb-4">
+          <input id="search-input" type="search" placeholder="Search rules…" class="input input-sm w-full sm:max-w-xs" autocomplete="off">
+          <span id="search-results-count" class="text-xs text-text-tertiary">0 results</span>
+          <div class="ml-auto flex gap-2">
+            <button id="expandAllBtn" class="btn btn-xs btn-secondary" type="button">Expand&nbsp;All</button>
+            <button id="collapseAllBtn" class="btn btn-xs btn-secondary" type="button">Collapse&nbsp;All</button>
+            <div class="relative">
+              <button id="exportMenuBtn" type="button" class="btn btn-xs btn-secondary" aria-haspopup="true" aria-controls="export-menu" aria-expanded="false">⋯<span class="sr-only">More actions</span></button>
+              <ul id="export-menu" class="hidden absolute right-0 mt-1 w-32 rounded border border-surface-3 bg-surface-1 shadow-lg text-sm">
+                <li><button type="button" class="w-full px-3 py-2 text-left hover:bg-surface-2" data-open-export-modal>Export…</button></li>
+              </ul>
+            </div>
         <div id="rule-tree" class="h-96 overflow-auto" data-tree-container>
           <!-- Tree nodes rendered by hierarchy_viewer.js -->
           <p class="text-text-secondary text-center">Loading tree...</p>
@@ -46,9 +46,38 @@
 
       <!-- Right Panel: Node Details -->
       <div class="lg:w-2/3 card card--glass p-6 glassmorphism">
+      <section class="grid grid-cols-1 lg:grid-cols-[1fr_260px] gap-6 mb-6">
+        <div id="diagram-preview" class="border border-surface-3 rounded shadow-inner overflow-auto min-h-[300px] flex items-center justify-center">
+          <span class="text-text-tertiary text-sm">Select a rule to load its diagram…</span>
+        </div>
+        <aside id="diagram-minimap" class="hidden lg:block border border-surface-3 rounded p-2 bg-surface-1">
+          <span class="text-text-tertiary text-xs">Minimap generating…</span>
+        </aside>
+      </section>
         <div class="flex items-center gap-4 mb-6 border-b border-border/50">
           {% for tab in ['Overview', 'Attributes', 'Relations', 'Raw JSON'] %}
             <button 
+      <aside id="nodeDetails" class="hidden lg:block w-full max-w-sm lg:sticky lg:top-20 self-start">
+  <div class="border border-surface-3 rounded bg-surface-1 shadow-sm">
+    <header class="px-4 py-3 border-b border-surface-3">
+      <h2 id="nodeName" class="text-base font-semibold truncate">Select a node…</h2>
+    </header>
+    <nav class="flex border-b border-surface-3" role="tablist">
+      <button id="tabAttributesBtn" class="flex-1 px-3 py-2 text-xs font-medium uppercase tracking-wide hover:bg-surface-2 focus:outline-none" data-tab="attributes" role="tab" aria-selected="true">Attributes</button>
+      <button id="tabActionsBtn" class="flex-1 px-3 py-2 text-xs font-medium uppercase tracking-wide hover:bg-surface-2 focus:outline-none" data-tab="actions" role="tab" aria-selected="false">Actions</button>
+      <button id="tabRelationsBtn" class="flex-1 px-3 py-2 text-xs font-medium uppercase tracking-wide hover:bg-surface-2 focus:outline-none" data-tab="relations" role="tab" aria-selected="false">Relations</button>
+    </nav>
+    <section id="attributesList" class="p-4 text-sm leading-relaxed" role="tabpanel">
+      <p class="text-text-tertiary italic">No attributes.</p>
+    </section>
+    <section id="actionsList" class="p-4 text-sm leading-relaxed hidden" role="tabpanel">
+      <p class="text-text-tertiary italic">No actions.</p>
+    </section>
+    <section id="relationsList" class="p-4 text-sm leading-relaxed hidden" role="tabpanel">
+      <p class="text-text-tertiary italic">No relations.</p>
+    </section>
+  </div>
+</aside>
               class="pb-2 text-text-secondary hover:text-primary-500 focus-ring transition-colors
               {% if tab == 'Overview' %}text-primary-500 border-b-2 border-primary-500{% endif %}"
               data-tab="{{ tab|lower|replace(' ', '-') }}"
@@ -142,7 +171,42 @@
   </section>
 {% endblock %}
 
+<aside id="searchHistoryPanel" class="fixed bottom-4 left-4 z-40 hidden max-w-xs w-72 rounded-lg border border-surface-3 bg-surface-1 shadow-lg">
+  <header class="flex items-center justify-between px-4 py-2 border-b border-surface-3">
+    <h3 class="text-sm font-semibold">Recent Searches</h3>
+    <button id="clearHistoryBtn" type="button" class="btn btn-ghost text-xs px-2 py-1" aria-label="Clear history">Clear</button>
+  </header>
+  <ul id="historyList" class="max-h-52 overflow-y-auto text-sm divide-y divide-surface-3"></ul>
+</aside>
+<div id="rawJsonModal" class="fixed inset-0 z-50 hidden items-center justify-center bg-black/40 backdrop-blur-sm">
+  <div class="bg-surface-1 w-full max-w-lg mx-4 rounded-lg shadow-lg overflow-hidden">
+    <header class="flex items-center justify-between px-4 py-3 border-b border-surface-3">
+      <h2 class="text-base font-semibold">Node RAW JSON</h2>
+      <div class="flex gap-2">
+        <button id="copyJsonBtn" class="btn btn-secondary btn-xs" type="button" aria-label="Copy JSON">Copy</button>
+        <button id="closeRawJsonModal" class="btn btn-ghost p-1" aria-label="Close">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5"><use href="#icon-x-mark"/></svg>
+        </button>
+      </div>
+    </header>
+    <pre id="rawJsonContent" class="p-4 text-xs leading-relaxed whitespace-pre-wrap overflow-auto bg-surface-0"></pre>
+  </div>
+</div>
 {% block scripts %}
+<div id="export-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-black/40 backdrop-blur-sm">
+  <div class="bg-surface-1 w-full max-w-sm mx-4 rounded-lg shadow-lg">
+    <header class="flex items-center justify-between px-4 py-3 border-b border-surface-3">
+      <h2 class="text-base font-semibold">Export Diagram</h2>
+      <button type="button" class="btn btn-ghost p-1" data-close-export-modal aria-label="Close">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5"><use href="#icon-x-mark"/></svg>
+      </button>
+    </header>
+    <div class="p-4 space-y-3">
+      <button id="exportImageBtn" class="btn btn-primary w-full" type="button">Save as PNG</button>
+      <button id="exportPdfBtn" class="btn btn-secondary w-full" type="button">Save as PDF</button>
+    </div>
+  </div>
+</div>
   {{ super() }}
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,8 +41,26 @@
       <a href="{{ url_for('main.catalog') }}" class="rc-btn rc-btn-outline" aria-label="View rule catalog">View Catalog</a>
       <a href="#quick-actions" class="rc-btn rc-btn-text">Quick Tour</a>
     </div>
+<header class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold">Dashboard</h1>
+  <time id="current-time" class="text-sm text-text-tertiary tracking-wider" datetime="">--:--</time>
+</header>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+  <div class="card bg-surface-2 p-4 rounded shadow">
+    <h3 class="text-sm font-medium text-text-secondary">Total Rules</h3>
+    <p id="totalRules" class="text-2xl font-semibold">0</p>
   </div>
-</section>
+  <div class="card bg-surface-2 p-4 rounded shadow">
+    <h3 class="text-sm font-medium text-text-secondary">Diagrams</h3>
+    <p id="diagramsProcessed" class="text-2xl font-semibold">0</p>
+  </div>
+  <div class="card bg-surface-2 p-4 rounded shadow">
+    <h3 class="text-sm font-medium text-text-secondary">Active Rules</h3>
+    <p id="activeRulesCount" class="text-2xl font-semibold">0</p>
+  </div>
+  <div id="recentActivity" class="col-span-2 md:col-span-3 space-y-2"></div>
+</div>
+
 
 
 {# ============================================================

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -34,7 +34,7 @@
 ========================================================= -->
 <section class="wrapper rc-container pb-24" aria-labelledby="rc-upload-heading">
   <div class="rc-upload-card rc-card rc-surface-1 mx-auto">
-    <form id="rc-upload-form"
+    <form id="uploadForm"
           action="{{ request.path }}"
           method="post"
           enctype="multipart/form-data"


### PR DESCRIPTION
## Summary
- add progress bar and help modal to base template
- wire new metrics IDs on dashboard
- add results panel for API test utility
- provide catalog container ID
- add search toolbar and modals to hierarchy viewer
- mark upload form with id

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687c033baf14833392b1186962c394db