### PR TITLE
Fix timezone handling in utilities

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Allow overriding the configuration file path via the ``CONFIG_PATH``
 # environment variable for flexible deployments.
@@ -45,7 +45,7 @@ class Config:
                 "rules": {},
                 "activity_log": [
                     {
-                        "timestamp": datetime.utcnow().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                         "action": "system",
                         "user": "init",
                         "details": "Activity log initialized",

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -2,7 +2,7 @@ import os
 import sys
 import types
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # Ensure project root is on the path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -14,9 +14,9 @@ werkzeug_utils_stub.secure_filename = lambda name: name
 sys.modules.setdefault('werkzeug', werkzeug_stub)
 sys.modules.setdefault('werkzeug.utils', werkzeug_utils_stub)
 
-import utils
-from utils import generate_mermaid_code
-from config import Config
+import utils  # noqa: E402
+from utils import generate_mermaid_code  # noqa: E402
+from config import Config  # noqa: E402
 
 
 def test_remove_all_quotes():
@@ -66,10 +66,10 @@ def test_rule_stats_and_trend(tmp_path, monkeypatch):
             'r2': {},
         },
         'activity_log': [
-            {'timestamp': (datetime.utcnow() - timedelta(days=1)).isoformat()},
-            {'timestamp': (datetime.utcnow() - timedelta(days=10)).isoformat()},
-            {'timestamp': (datetime.utcnow() - timedelta(days=40)).isoformat()},
-            {'timestamp': (datetime.utcnow() - timedelta(days=80)).isoformat()},
+            {'timestamp': (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()},
+            {'timestamp': (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()},
+            {'timestamp': (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()},
+            {'timestamp': (datetime.now(timezone.utc) - timedelta(days=80)).isoformat()},
         ],
     }
     (Config.ACTIVITY_LOG).write_text(json.dumps(data))

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import types
-import json
-from pathlib import Path
 
 # Ensure project root is on the import path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/utils.py
+++ b/utils.py
@@ -501,7 +501,7 @@ def get_rule_stats() -> dict:
     try:
         with open(Config.ACTIVITY_LOG, "r", encoding="utf-8") as f:
             data = json.load(f)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         totals = {
             "total_rules": len(data.get("rules", {})),
             "last_7_days": 0,
@@ -531,7 +531,7 @@ def get_activity_trend(days: int = 30) -> list[dict]:
     try:
         with open(Config.ACTIVITY_LOG, "r", encoding="utf-8") as f:
             data = json.load(f)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         start_date = now.date() - timedelta(days=days - 1)
         counts = { (start_date + timedelta(days=i)).isoformat(): 0 for i in range(days) }
         for entry in data.get("activity_log", []):


### PR DESCRIPTION
## Summary
- use timezone-aware timestamps in config and utils
- update tests for new timezone logic
- remove unused imports in misc tests

## Testing
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_687c163d77108333af76559a3233eede