### PR TITLE
Improve JS initialization

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -168,10 +168,12 @@ document.addEventListener("DOMContentLoaded", () => {
   // ======================
   // 4. GLOBAL EXPORTS
   // ======================
-  window.app = {
+  window.AppUtils = window.AppUtils || {};
+  Object.assign(window.AppUtils, {
     initAnimations,
     setupBackToTop,
     setupSearchInputs,
     handleLoadMore,
-  };
+  });
+  window.app = window.AppUtils;
 });

--- a/static/js/footer.js
+++ b/static/js/footer.js
@@ -1,25 +1,28 @@
 // Footer behaviour
 // Refactored for ARIA, accessibility, and maintainability
+(function () {
+  document.addEventListener("DOMContentLoaded", () => {
+    // Set current year in footer
+    const yearEl = document.getElementById("current-year");
+    if (yearEl) yearEl.textContent = new Date().getFullYear();
 
-// Set current year in footer
-const yearEl = document.getElementById("current-year");
-if (yearEl) yearEl.textContent = new Date().getFullYear();
+    // Alpine.js help system dropdown
+    if (window.Alpine) {
+      document.addEventListener("alpine:init", () => {
+        Alpine.data("helpSystem", () => ({
+          open: false,
+          toggle() {
+            this.open = !this.open;
+          },
+        }));
+      });
+    }
 
-// Alpine.js help system dropdown
-if (window.Alpine) {
-  document.addEventListener("alpine:init", () => {
-    Alpine.data("helpSystem", () => ({
-      open: false,
-      toggle() {
-        this.open = !this.open;
-      },
-    }));
+    // Ensure newsletter feedback uses aria-live for accessibility
+    const newsletterForm = document.querySelector('form[action*="newsletter"]');
+    if (newsletterForm) {
+      const feedback = newsletterForm.querySelector('.form-feedback');
+      if (feedback) feedback.setAttribute('aria-live', 'polite');
+    }
   });
-}
-
-// Ensure newsletter feedback uses aria-live for accessibility
-const newsletterForm = document.querySelector('form[action*="newsletter"]');
-if (newsletterForm) {
-  let feedback = newsletterForm.querySelector('.form-feedback');
-  if (feedback) feedback.setAttribute('aria-live', 'polite');
-}
+})();

--- a/static/js/header.js
+++ b/static/js/header.js
@@ -1,60 +1,64 @@
 // Header interactions
 // Refactored for DRY theme logic, ARIA, debouncing, and maintainability
-
-// Alpine.js dropdown for header
-if (window.Alpine) {
-  document.addEventListener("alpine:init", () => {
-    Alpine.data("dropdown", () => ({
-      open: false,
-      toggle() {
-        this.open = !this.open;
-      },
-    }));
-  });
-}
-
-// Mobile menu toggle with debouncing and ARIA
-const mobileMenuBtn = document.getElementById("mobile-menu-btn");
-if (mobileMenuBtn) {
-  let debounce = false;
-  mobileMenuBtn.addEventListener("click", function () {
-    if (debounce) return;
-    debounce = true;
-    setTimeout(() => (debounce = false), 300);
-    const menu = document.getElementById("mobile-menu");
-    const isExpanded = this.getAttribute("aria-expanded") === "true";
-    this.setAttribute("aria-expanded", !isExpanded);
-    menu.classList.toggle("hidden");
-    const icon = this.querySelector("i");
-    if (icon) {
-      icon.classList.toggle("fa-bars", isExpanded);
-      icon.classList.toggle("fa-times", !isExpanded);
+(function () {
+  document.addEventListener("DOMContentLoaded", () => {
+    // Alpine.js dropdown for header
+    if (window.Alpine) {
+      document.addEventListener("alpine:init", () => {
+        Alpine.data("dropdown", () => ({
+          open: false,
+          toggle() {
+            this.open = !this.open;
+          },
+        }));
+      });
     }
+
+    // Mobile menu toggle with debouncing and ARIA
+    const mobileMenuBtn = document.getElementById("mobile-menu-btn");
+    if (mobileMenuBtn) {
+      let debounce = false;
+      mobileMenuBtn.addEventListener("click", function () {
+        if (debounce) return;
+        debounce = true;
+        setTimeout(() => (debounce = false), 300);
+        const menu = document.getElementById("mobile-menu");
+        const isExpanded = this.getAttribute("aria-expanded") === "true";
+        this.setAttribute("aria-expanded", !isExpanded);
+        menu.classList.toggle("hidden");
+        const icon = this.querySelector("i");
+        if (icon) {
+          icon.classList.toggle("fa-bars", isExpanded);
+          icon.classList.toggle("fa-times", !isExpanded);
+        }
+      });
+    }
+
+    // Theme toggle (delegates to AppUtils.toggleTheme for DRYness)
+    const themeToggle = document.getElementById("theme-toggle");
+    if (themeToggle && window.AppUtils && window.AppUtils.toggleTheme) {
+      themeToggle.addEventListener("click", window.AppUtils.toggleTheme);
+    }
+
+    highlightCurrentNav();
   });
-}
 
-// Theme toggle (delegates to AppUtils.toggleTheme for DRYness)
-const themeToggle = document.getElementById("theme-toggle");
-if (themeToggle && window.AppUtils && window.AppUtils.toggleTheme) {
-  themeToggle.addEventListener("click", window.AppUtils.toggleTheme);
-}
-
-// Highlight current navigation link and set aria-current
-function highlightCurrentNav() {
-  document
-    .querySelectorAll(".nav-link, .mobile-nav-link, .sidebar-link")
-    .forEach((link) => {
-      if (link.getAttribute("href") === window.location.pathname) {
-        link.classList.add(
-          "text-primary-600",
-          "dark:text-primary-400",
-          "font-medium",
-          "active"
-        );
-        link.setAttribute("aria-current", "page");
-        const underline = link.querySelector("span:last-child");
-        if (underline) underline.classList.add("w-4/5", "left-[10%]");
-      }
-    });
-}
-document.addEventListener("DOMContentLoaded", highlightCurrentNav);
+  // Highlight current navigation link and set aria-current
+  function highlightCurrentNav() {
+    document
+      .querySelectorAll(".nav-link, .mobile-nav-link, .sidebar-link")
+      .forEach((link) => {
+        if (link.getAttribute("href") === window.location.pathname) {
+          link.classList.add(
+            "text-primary-600",
+            "dark:text-primary-400",
+            "font-medium",
+            "active"
+          );
+          link.setAttribute("aria-current", "page");
+          const underline = link.querySelector("span:last-child");
+          if (underline) underline.classList.add("w-4/5", "left-[10%]");
+        }
+      });
+  }
+})();

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -1,35 +1,40 @@
 "use strict";
-/*helpers.js*/
-const showLoadingSpinner = () => {
-  const loadingSpinner = document.getElementById("loadingSpinner");
-  if (loadingSpinner) {
-    loadingSpinner.classList.add("show");
-    loadingSpinner.setAttribute("aria-busy", "true");
-  }
-};
+(function (global) {
+  const Helpers = {};
 
-const hideLoadingSpinner = () => {
-  const loadingSpinner = document.getElementById("loadingSpinner");
-  if (loadingSpinner) {
-    loadingSpinner.classList.remove("show");
-    loadingSpinner.removeAttribute("aria-busy");
-  }
-};
+  Helpers.showLoadingSpinner = () => {
+    const loadingSpinner = document.getElementById("loadingSpinner");
+    if (loadingSpinner) {
+      loadingSpinner.classList.add("show");
+      loadingSpinner.setAttribute("aria-busy", "true");
+    }
+  };
 
-const waitForSvg = (container) =>
-  new Promise((resolve, reject) => {
-    const observer = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        if (mutation.addedNodes.length) {
-          const svgElement = container.querySelector("svg");
-          if (svgElement) {
-            observer.disconnect();
-            resolve(svgElement);
-            return;
+  Helpers.hideLoadingSpinner = () => {
+    const loadingSpinner = document.getElementById("loadingSpinner");
+    if (loadingSpinner) {
+      loadingSpinner.classList.remove("show");
+      loadingSpinner.removeAttribute("aria-busy");
+    }
+  };
+
+  Helpers.waitForSvg = (container) =>
+    new Promise((resolve, reject) => {
+      const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.addedNodes.length) {
+            const svgElement = container.querySelector("svg");
+            if (svgElement) {
+              observer.disconnect();
+              resolve(svgElement);
+              return;
+            }
           }
         }
-      }
+      });
+      observer.observe(container, { childList: true, subtree: true });
+      setTimeout(() => reject(new Error("SVG load timeout")), 5000);
     });
-    observer.observe(container, { childList: true, subtree: true });
-    setTimeout(() => reject(new Error("SVG load timeout")), 5000);
-  });
+
+  global.Helpers = Helpers;
+})(window);


### PR DESCRIPTION
## Summary
- wrap dashboard, header, and footer scripts in DOM ready handlers
- export helper functions under `window.Helpers`
- extend global AppUtils instead of overwriting

## Test Results
- `pytest -v` passed


------
https://chatgpt.com/codex/tasks/task_e_687c3d5283088333911c96b486a568d5