### PR TITLE
Improve UI helpers and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A Flask web application for organizing and visualizing complex rule sets with co
 - **Bear Light** theme refreshed for a brighter look
 - **Accessibility** focused design
 - **Help System** (`Shift+/` shortcut)
+- **Documentation Reading Progress** for orientation
+- **Unified Toast Notifications** across tools
 
 ## Quick Start
 

--- a/static/js/documentation.js
+++ b/static/js/documentation.js
@@ -3,6 +3,13 @@
 document.addEventListener("DOMContentLoaded", function () {
   const sections = document.querySelectorAll(".content-section");
   const tocLinks = document.querySelectorAll(".toc-link");
+  const progressBar = document.getElementById("reading-progress");
+  const progressLabel = document.getElementById("reading-percentage");
+  const mobileTocToggle = document.getElementById("mobile-toc-toggle");
+  const mobileToc = document.getElementById("mobile-toc");
+  const printBtn = document.getElementById("print-docs");
+  const shareBtn = document.getElementById("share-docs");
+  const bookmarkBtn = document.getElementById("bookmark-docs");
 
   function updateActiveTocLink() {
     let currentSection = "";
@@ -21,8 +28,21 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
-  window.addEventListener("scroll", updateActiveTocLink);
+  function updateReadingProgress() {
+    if (!progressBar || !progressLabel) return;
+    const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+    const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    const pct = Math.min(100, Math.round((scrollTop / scrollHeight) * 100));
+    progressBar.style.width = pct + "%";
+    progressLabel.textContent = pct + "%";
+  }
+
+  window.addEventListener("scroll", () => {
+    updateActiveTocLink();
+    updateReadingProgress();
+  });
   updateActiveTocLink();
+  updateReadingProgress();
 
   tocLinks.forEach((link) => {
     link.addEventListener("click", function (e) {
@@ -38,4 +58,43 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     });
   });
+
+  if (mobileTocToggle && mobileToc) {
+    mobileTocToggle.addEventListener("click", () => {
+      const expanded = mobileTocToggle.getAttribute("aria-expanded") === "true";
+      mobileTocToggle.setAttribute("aria-expanded", String(!expanded));
+      mobileToc.classList.toggle("hidden", expanded);
+    });
+  }
+
+  if (printBtn) {
+    printBtn.addEventListener("click", () => window.print());
+  }
+
+  if (shareBtn) {
+    shareBtn.addEventListener("click", async () => {
+      const shareData = { title: document.title, url: location.href };
+      try {
+        if (navigator.share) {
+          await navigator.share(shareData);
+        } else {
+          await navigator.clipboard.writeText(location.href);
+          Helpers.showToast("Link copied to clipboard", "success");
+        }
+      } catch (err) {
+        Helpers.showToast("Unable to share", "error");
+      }
+    });
+  }
+
+  if (bookmarkBtn) {
+    bookmarkBtn.addEventListener("click", () => {
+      try {
+        localStorage.setItem("docsBookmarked", location.href);
+        Helpers.showToast("Documentation bookmarked", "success");
+      } catch (e) {
+        Helpers.showToast("Bookmark failed", "error");
+      }
+    });
+  }
 });

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -1,4 +1,5 @@
 "use strict";
+// Small utility helpers shared across pages
 (function (global) {
   const Helpers = {};
 
@@ -15,6 +16,20 @@
     if (loadingSpinner) {
       loadingSpinner.classList.remove("show");
       loadingSpinner.removeAttribute("aria-busy");
+    }
+  };
+
+  /**
+   * Display a toast notification if the global app util is available
+   * Falls back to alert() when not present
+   * @param {string} message - Message to display
+   * @param {string} [type="info"] - success|error|info
+   */
+  Helpers.showToast = (message, type = "info") => {
+    if (global.app && typeof global.app.showToast === "function") {
+      global.app.showToast(message, type);
+    } else {
+      alert(`${type.toUpperCase()}: ${message}`);
     }
   };
 
@@ -36,5 +51,6 @@
       setTimeout(() => reject(new Error("SVG load timeout")), 5000);
     });
 
+  // Export helpers globally
   global.Helpers = Helpers;
 })(window);

--- a/static/js/profile.js
+++ b/static/js/profile.js
@@ -302,3 +302,23 @@ systemThemeMediaQuery.addEventListener("change", () => {
 
 // Dispatch initial profile load event
 dispatchProfileUpdate(loadProfile());
+
+/**
+ * Expose profile API globally for non-module scripts
+ * @type {Object}
+ */
+export const ProfileAPI = {
+  loadProfile,
+  saveProfile,
+  updateProfile,
+  resetProfile,
+  getEffectiveTheme,
+  toggleTheme,
+  addSearchQuery,
+  addFavourite,
+  removeFavourite,
+};
+
+// Attach to window so legacy scripts can access the API
+// Allows non-module scripts to call profile functions
+window.Profile = ProfileAPI;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,4 +1,5 @@
 "use strict";
+// Advanced search page interactions with accessible toast notifications
 document.addEventListener("DOMContentLoaded", () => {
   console.log("search.js loaded");
 
@@ -18,6 +19,10 @@ document.addEventListener("DOMContentLoaded", () => {
     pagination: document.getElementById("pagination"),
     spinner: document.getElementById("spinner"),
     toast: document.getElementById("toast"),
+    toastTitle: document.getElementById("toastTitle"),
+    toastMessage:
+      document.getElementById("toastMessage") ||
+      document.getElementById("toast-message"),
   };
 
   // Check if all elements are found
@@ -504,6 +509,10 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function showToast(message, type = "info", title = "") {
+    if (window.Helpers && typeof window.Helpers.showToast === "function") {
+      window.Helpers.showToast(message, type);
+      return;
+    }
     if (!elements.toast) return;
     elements.toast.classList.remove("hidden");
     elements.toast.setAttribute("role", "status");
@@ -515,7 +524,9 @@ document.addEventListener("DOMContentLoaded", () => {
       elements.toast.classList.add("bg-red-700");
       elements.toast.classList.remove("bg-emerald-700");
     }
-    if (elements.toastTitle) elements.toastTitle.textContent = title || (type === "success" ? "Success" : type === "error" ? "Error" : "Info");
+    if (elements.toastTitle)
+      elements.toastTitle.textContent =
+        title || (type === "success" ? "Success" : type === "error" ? "Error" : "Info");
     if (elements.toastMessage) elements.toastMessage.textContent = message;
     elements.toast.focus();
     setTimeout(() => {

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -33,6 +33,7 @@
         <div class="w-full bg-gray-700 rounded-full h-1.5">
           <div id="reading-progress" class="bg-gradient-to-r from-primary-500 to-secondary-500 h-1.5 rounded-full transition-all duration-300" style="width: 0%"></div>
         </div>
+        <p class="sr-only">Track your place in the article</p>
       </div>
     </div>
     


### PR DESCRIPTION
## Summary
- expose profile functions globally
- extend JS helpers with toast API
- add reading progress and sharing tools to documentation page
- refine toast handling in search module
- mention new features in README

## Testing
- `pytest -v`
- `npm test` *(no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_687c3f07b0c08333924b2858781f17bd