### PR TITLE
Fix missing blueprint import

### DIFF
--- a/app.py
+++ b/app.py
@@ -280,9 +280,10 @@ def _register_cli(app: Flask) -> None:
 # 3. Legacy support — keep Gunicorn & Flask CLI happy
 # --------------------------------------------------------------------------- #
 
-app = create_app()
-app.config['TEMPLATES_AUTO_RELOAD'] = True
-if __name__ == "__main__":
-    port = int(os.environ.get("PORT", 8080))
-    debug = os.getenv("FLASK_ENV") == "development"
-    app.run(host="0.0.0.0", port=port, debug=debug)
+if not os.environ.get("RC_SKIP_CREATE_APP"):
+    app = create_app()
+    app.config['TEMPLATES_AUTO_RELOAD'] = True
+    if __name__ == "__main__":
+        port = int(os.environ.get("PORT", 8080))
+        debug = os.getenv("FLASK_ENV") == "development"
+        app.run(host="0.0.0.0", port=port, debug=debug)

--- a/routes/core.py
+++ b/routes/core.py
@@ -50,7 +50,7 @@ diagrams = Blueprint("diagrams", __name__, url_prefix="/diagrams")
 main = Blueprint("main", __name__)
 auth = Blueprint("auth", __name__, url_prefix="/auth")
 upload = Blueprint("upload", __name__, url_prefix="/upload")
-user = Blueprint("user", __name__, url_prefix="/user")
+user_routes = Blueprint("user", __name__, url_prefix="/user")
 
 # ---------------------------------------------------------------------------
 # Helper Functions


### PR DESCRIPTION
## Summary
- rename user blueprint to `user_routes`
- respect `RC_SKIP_CREATE_APP` env var when importing `app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce255f5ec83339c03043526e6c9ef