### PR TITLE
Fix missing catalog route

### DIFF
--- a/routes/core.py
+++ b/routes/core.py
@@ -318,6 +318,16 @@ def index() -> str:
         current_app.logger.error(f"Index page error: {e}", exc_info=True)
         abort(500, description="Failed to load home page")
 
+
+@main.route("/catalog")
+def catalog() -> str:
+    """Display the diagram catalog page."""
+    try:
+        return render_template("catalog.html")
+    except Exception as e:
+        current_app.logger.error(f"Catalog page error: {e}", exc_info=True)
+        abort(500, description="Failed to load catalog")
+
 # ---------------------------------------------------------------------------
 # Context Processors
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a `/catalog` view

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687d14c427b88333bd4501be055523e3