### PR TITLE
Add flake8 linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+exclude = .git,__pycache__,node_modules,instance,uploads,static
+extend-ignore = E203,W503

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Flask web application for organizing and visualizing complex rule sets with co
 ## Quick Start
 
 ```bash
-# Set up environment
+# Set up environment (Python 3.10+, Node.js 16+ recommended)
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
@@ -181,6 +181,7 @@ Follow these basics when contributing:
 - Create topic branches instead of pushing to `main`
 - Run `pytest -v`, `npm run build:css`, and `npm run build:js` before opening a PR
 - Keep docs updated across README and the site
+- Ensure `flake8` passes for linting
 - Link `tools/pre-commit` into `.git/hooks` to catch missing element IDs
 - See [AGENTS.md](AGENTS.md) for the full checklist
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ waitress==3.0.0
 wcwidth==0.2.13
 webassets==2.0
 Werkzeug==3.0.3
+flake8==7.0.0

--- a/routes/core.py
+++ b/routes/core.py
@@ -8,6 +8,8 @@ This module organizes all application routes into logical blueprints with:
 - Secure file uploads
 - CSRF protection
 - Structured API responses
+All route handlers document inputs and outputs per the style guide in
+``AGENTS.md``.
 """
 
 from __future__ import annotations

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -244,6 +244,7 @@
           <li>Create topic branches instead of committing to <code>main</code></li>
           <li>Run <code>pytest -v</code>, <code>npm run build:css</code>, and <code>npm run build:js</code> before PRs</li>
           <li>Update documentation alongside your code</li>
+          <li>Run <code>flake8</code> and fix lint errors</li>
           <li>Link <code>tools/pre-commit</code> into <code>.git/hooks</code> to catch missing IDs</li>
         </ul>
         <p class="text-gray-200 mt-4">

--- a/tests/test_utils_auth.py
+++ b/tests/test_utils_auth.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Stub flask_login current_user for get_current_user
+flask_login_stub = types.ModuleType('flask_login')
+flask_login_stub.current_user = types.SimpleNamespace(is_authenticated=False, username='user')
+sys.modules.setdefault('flask_login', flask_login_stub)
+
+import utils  # noqa: E402
+
+
+def test_validate_email():
+    assert utils.validate_email('test@example.com')
+    assert not utils.validate_email('invalid-email')
+
+
+def test_validate_password():
+    assert utils.validate_password('abc12345')
+    assert not utils.validate_password('short1')

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
 python3 tools/check_ids.py || exit 1
+flake8 || exit 1

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,8 @@
-"""Unified utility module for Rules Central."""
+"""Unified utility module for Rules Central.
+
+All helpers should include clear docstrings following the conventions
+outlined in ``AGENTS.md`` to keep the codebase consistent.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- integrate flake8 configuration
- enforce lint checks in pre-commit script
- document flake8 usage in README and docs
- clarify module docstrings per AGENTS guidelines
- add basic auth utility tests

## Testing
- `pytest -v`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2c5e32d483338759a0f9309f9a95