### PR TITLE
Update config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,14 @@ Environment variables:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CONFIG_PATH` | Path to config file | `config/default.json` |
+| `CONFIG_PATH` | Path to config file | `config/config.json` |
 | `SECRET_KEY` | Application secret key | Randomly generated |
 | `UPLOAD_FOLDER` | File upload directory | `./uploads` |
 | `DIAGRAMS_FOLDER` | Diagram storage | `./diagrams` |
 | `PORT` | Server port | `8080` |
+
+Customize the configuration location by setting the
+`CONFIG_PATH` environment variable to an alternate JSON file.
 
 ## Deployment
 

--- a/config.py
+++ b/config.py
@@ -4,6 +4,9 @@ This module provides:
 - Configuration file loading from JSON
 - Application constants and paths
 - Data directory initialization
+
+The configuration file path defaults to ``config/config.json`` but can
+be overridden with the ``CONFIG_PATH`` environment variable.
 """
 
 import json

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -233,9 +233,19 @@
             <code>src/css/tokens.css</code>.
           </p>
         </div>
-      </section>
+        </section>
 
-      <!-- Contributing Section -->
+        <!-- Configuration Section -->
+        <section id="configuration" class="docs-section mb-12">
+          <h2 class="text-2xl font-bold text-white mb-3">Configuration</h2>
+          <p class="text-gray-200 mb-4">
+            Default settings are read from
+            <code>config/config.json</code>. Set the
+            <code>CONFIG_PATH</code> environment variable to use a custom file.
+          </p>
+        </section>
+
+        <!-- Contributing Section -->
       <section id="contributing" class="docs-section mb-12">
         <h2 class="text-2xl font-bold text-white mb-3">Contributing</h2>
         <p class="text-gray-200 mb-4">


### PR DESCRIPTION
## Summary
- fix default config path in README
- explain how to override config path
- document config path in docs page and config module

## Testing
- `pytest -v`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d6d7f2d088333ba15befb0c357f8d