### PR TITLE
Fix docs URL in quick help modal

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -315,7 +315,7 @@
         <li><kbd class="kbd">?</kbd> anywhere to reopen this help</li>
         <li><kbd class="kbd">⌘</kbd><kbd>←/→</kbd> to collapse / expand all nodes</li>
       </ul>
-      <p class="pt-2 text-text-tertiary">Need deeper docs? Visit <a href="{{ url_for(main.docs) }}" class="link">Documentation</a>.</p>
+      <p class="pt-2 text-text-tertiary">Need deeper docs? Visit <a href="{{ url_for('routes.full_help') }}" class="link">Documentation</a>.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- fix link to documentation in the Quick Help modal

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687e46e7632c833396c2a555a03d1d26