### PR TITLE
Remove inline styles from index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,23 +3,7 @@
 {% block title %}Dashboard | Rules Central{% endblock title %}
 {% block description %}Centralized rules management dashboard with real-time insights, modern UI, and analytics.{% endblock description %}
 
-{% block styles %}
-<style>
-  /* Modern color scheme */
-  :root {
-    --primary: #6366f1;
-    --primary-dark: #4f46e5;
-    --secondary: #f43f5e;
-    --accent: #10b981;
-    --dark: #1e293b;
-    --light: #f8fafc;
-    --gray: #94a3b8;
-    --success: #10b981;
-    --warning: #f59e0b;
-    --danger: #ef4444;
-  }
-</style>
-{% endblock styles %}
+{% block styles %}{% endblock styles %}
 
 {% block content %}
 


### PR DESCRIPTION
## Summary
- rely on custom.css for all templates
- delete redundant style block from `index.html`

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6880380350688333a37d502fcaaf320a