### PR TITLE
Add density toggle button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -257,8 +257,8 @@
         {% endif %}
 
         <!-- Theme toggle -->
-        <button id="theme-toggle" 
-                class="theme-toggle-btn" 
+        <button id="theme-toggle"
+                class="theme-toggle-btn"
                 type="button"
                 aria-label="Toggle dark mode"
                 title="Toggle theme"
@@ -269,6 +269,9 @@
           <svg class="theme-icon-dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
           </svg>
+        </button>
+        <button id="density-toggle" class="theme-toggle-btn" type="button" aria-label="Toggle density" title="Toggle density">
+          <i class="fas fa-compress-arrows-alt"></i>
         </button>
       </div>
     </div>

--- a/templates/hierarchy_viewer.html
+++ b/templates/hierarchy_viewer.html
@@ -211,5 +211,23 @@
   {{ super() }}
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <script>
+    (function(){
+      const btn = document.getElementById('density-toggle');
+      const key = 'rc-density';
+      try {
+        const saved = localStorage.getItem(key);
+        if(saved === 'dense') document.body.classList.add('dense');
+      } catch(e) {}
+      if(btn){
+        btn.addEventListener('click',()=>{
+          document.body.classList.toggle('dense');
+          try {
+            localStorage.setItem(key, document.body.classList.contains('dense') ? 'dense' : 'normal');
+          } catch(e) {}
+        });
+      }
+    })();
+  </script>
   <script type="module" src="{{ url_for('static', filename='js/hierarchy_viewer.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add density toggle control to base layout
- store density preference in local storage
- initialize density state on hierarchy viewer load

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6886d63590588333904830588c15a348