### PR TITLE
fix: add dark token and status styles

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,12 +35,14 @@
   --color-surface: white;
   --color-primary: var(--primary-600);
   --color-primary-hover: var(--primary-700);
+  --background: var(--color-bg);
   
   /* Dark Mode */
   --dark-bg: var(--gray-900);
   --dark-text: var(--gray-50);
   --dark-border: var(--gray-700);
   --dark-surface: var(--gray-800);
+  --dark-600: #334155; /* used for hover states */
   
   /* Spacing */
   --space-xs: 0.25rem;

--- a/src/css/pages_components.css
+++ b/src/css/pages_components.css
@@ -290,3 +290,90 @@
     background-color: color-mix(in srgb, var(--color-error) 12%, transparent);
   }
 }
+
+/* API Method Buttons */
+.api-method-btn {
+  transition: all 0.2s ease;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  border: none;
+  cursor: pointer;
+}
+.api-method-btn.active {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Response Tabs */
+.response-tab {
+  transition: all 0.2s ease;
+  position: relative;
+  border: none;
+  background: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0.75rem 1.25rem;
+  font-size: 0.95rem;
+}
+.response-tab.active {
+  color: var(--color-primary);
+}
+.response-tab.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--color-primary);
+}
+
+/* Status Badges */
+.status-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+}
+.status-2xx {
+  background-color: rgba(16, 185, 129, 0.1);
+  color: var(--success-500);
+}
+.status-4xx {
+  background-color: rgba(245, 158, 11, 0.1);
+  color: var(--warning-500);
+}
+.status-5xx {
+  background-color: rgba(239, 68, 68, 0.1);
+  color: var(--danger-500);
+}
+
+/* Status Indicator Dots */
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 4px;
+}
+.status-dot.active { background-color: #10B981; }
+.status-dot.draft { background-color: #F59E0B; }
+.status-dot.deprecated { background-color: #EF4444; }
+
+/* Search Suggestions */
+.search-suggestions .suggestion-item,
+.search-suggestions .history-item {
+  transition: background-color 0.2s;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+.search-suggestions .suggestion-item:last-child,
+.search-suggestions .history-item:last-child {
+  border-bottom: none;
+}
+
+/* Documentation Header Icon */
+.doc-header .icon {
+  margin-right: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- define missing `--background` and `--dark-600` variables
- add API method button, response tab, and status badge styles
- fix search suggestion border typo and doc header icon spacing

## Testing
- `npm run build:css` *(fails: Missing script "build:css")*
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_688fe4536ed88333b40816030c17b91c