### PR TITLE
Improve alt text for carousel and features

### DIFF
--- a/templates/_components/macros.html
+++ b/templates/_components/macros.html
@@ -79,23 +79,23 @@
 {%- endmacro %}
 
 {% macro DeviceCarousel(images) -%}
-<div 
-  x-data="carousel({{ images|length }})" 
+<div
+  x-data="carousel({{ images|length }})"
   class="relative aspect-[3/2] overflow-hidden rounded-xl shadow-lg"
 >
   {% for img in images %}
-  <picture 
-    class="absolute inset-0 transition-opacity duration-700 motion-reduce:duration-0" 
+  <picture
+    class="absolute inset-0 transition-opacity duration-700 motion-reduce:duration-0"
     :class="current === {{ loop.index0 }} ? 'opacity-100' : 'opacity-0 pointer-events-none'"
     aria-hidden="{{ 'false' if loop.first else 'true' }}"
   >
-    <source srcset="{{ url_for('static', filename=img + '.webp') }}" type="image/webp">
-    <source srcset="{{ url_for('static', filename=img + '.png') }}" type="image/png">
-    <img 
-      src="{{ url_for('static', filename=img + '.png') }}" 
-      alt="Screenshot of Rules Central interface {{ loop.index }}" 
-      class="w-full h-full object-contain" 
-      loading="lazy" 
+    <source srcset="{{ url_for('static', filename=img.path + '.webp') }}" type="image/webp">
+    <source srcset="{{ url_for('static', filename=img.path + '.png') }}" type="image/png">
+    <img
+      src="{{ url_for('static', filename=img.path + '.png') }}"
+      alt="{{ img.alt }}"
+      class="w-full h-full object-contain"
+      loading="lazy"
       decoding="async"
     >
   </picture>
@@ -146,7 +146,7 @@
 </section>
 {%- endmacro %}
 
-{% macro FeatureRow(title, desc, img_path, reverse=False, cta_href=None) -%}
+{% macro FeatureRow(title, desc, img_path, reverse=False, cta_href=None, img_alt=None) -%}
 <section class="py-18 px-4">
   <div class="container flex flex-col md:flex-row items-center gap-10 {% if reverse %}md:flex-row-reverse{% endif %}">
     <div class="md:w-1/2 space-y-6">
@@ -165,11 +165,11 @@
       <picture>
         <source srcset="{{ url_for('static', filename=img_path + '.webp') }}" type="image/webp">
         <source srcset="{{ url_for('static', filename=img_path + '.png') }}" type="image/png">
-        <img 
-          src="{{ url_for('static', filename=img_path + '.png') }}" 
-          alt="Visual representation of {{ title }}" 
-          class="w-full rounded-xl shadow-lg" 
-          loading="lazy" 
+        <img
+          src="{{ url_for('static', filename=img_path + '.png') }}"
+          alt="{{ img_alt or ('Illustration of ' ~ title) }}"
+          class="w-full rounded-xl shadow-lg"
+          loading="lazy"
           decoding="async"
         >
       </picture>

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,10 +3,35 @@
 
 {% block content %}
 {{ ui.Nav() }}
-{{ ui.Hero('Build powerful rules fast','Quickly search, visualize, and export your automations.', url_for('auth.signup'), ['images/device-mac','images/device-ipad','images/device-iphone']) }}
-{{ ui.FeatureRow('Search across every rule','Fuzzy search uncovers matches instantly across your repository.','images/feature-search') }}
-{{ ui.FeatureRow('Visual rule builder','Construct complex logic with an intuitive drag & drop interface.','images/feature-builder', True) }}
-{{ ui.FeatureRow('One-click exports','Share PDF or PNG snapshots without compromising privacy.','images/feature-export') }}
+{{ ui.Hero(
+  'Build powerful rules fast',
+  'Quickly search, visualize, and export your automations.',
+  url_for('auth.signup'),
+  [
+    {'path': 'images/device-mac', 'alt': 'Mac app dashboard with rule list'},
+    {'path': 'images/device-ipad', 'alt': 'Tablet interface showing rule details'},
+    {'path': 'images/device-iphone', 'alt': 'Mobile view displaying automation overview'}
+  ]
+) }}
+{{ ui.FeatureRow(
+  'Search across every rule',
+  'Fuzzy search uncovers matches instantly across your repository.',
+  'images/feature-search',
+  img_alt='Interface highlighting fuzzy rule search results'
+) }}
+{{ ui.FeatureRow(
+  'Visual rule builder',
+  'Construct complex logic with an intuitive drag & drop interface.',
+  'images/feature-builder',
+  True,
+  img_alt='Drag-and-drop rule builder workspace'
+) }}
+{{ ui.FeatureRow(
+  'One-click exports',
+  'Share PDF or PNG snapshots without compromising privacy.',
+  'images/feature-export',
+  img_alt='Export options dialog for sharing rules'
+) }}
 {{ ui.FeatureGrid([
   {'icon':'fa-solid fa-filter','title':'Smart filtering','desc':'Combine tags and attributes for pinpoint accuracy.'},
   {'icon':'fa-solid fa-bolt','title':'Automation ready','desc':'Trigger webhooks whenever rules change.'},


### PR DESCRIPTION
## Summary
- allow passing descriptive alt text in carousel and feature macros
- use context-specific alt text for landing page screenshots

## Testing
- `pytest -v` *(fails: TypeError required field "lineno" missing from alias)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688fd68fc3448333b6c878cecaa5c6c2