### PR TITLE
feat: split index into partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Recommended production stack:
 ├── routes/               # All application routes
 │   └── core.py           # All routes (auto-discovered)
 ├── static/               # Static assets
-├── templates/            # Jinja2 templates
+├── templates/            # Jinja2 templates (index uses partials)
 ├── config/               # Configuration files
 └── tests/                # Test suite
 ```
@@ -236,4 +236,3 @@ Key improvements:
    - Improved TOC
    - Consistent headers
    - Better section links
-

--- a/routes/core.py
+++ b/routes/core.py
@@ -8,6 +8,7 @@ This module organizes all application routes into logical blueprints with:
 - Secure file uploads
 - CSRF protection
 - Structured API responses
+- Home dashboard template composition via partials.
 All route handlers document inputs and outputs per the style guide in
 ``AGENTS.md``.
 """

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -391,6 +391,18 @@
         </div>
       </section>
 
+      <section id="template-composition" class="docs-section mt-12">
+        <h2 class="text-2xl font-bold text-white mb-4">Template Composition</h2>
+        <p class="text-gray-300 mb-4">
+          The home dashboard template is split into partials so sections can be reused and maintained independently.
+          Look for the dashboard-specific partials in <code>templates/partials/</code>.
+        </p>
+        <div class="bg-white/5 rounded-lg border border-white/10 p-4">
+          <p class="text-gray-300 text-sm mb-3">Example include:</p>
+          <pre class="text-xs text-gray-200 bg-black/40 p-3 rounded-md overflow-x-auto"><code>{% include "partials/index_metrics.html" %}</code></pre>
+        </div>
+      </section>
+
       <!-- Footer with helpful links -->
       <footer class="mt-16 pt-8 border-t border-white/10">
         <div class="flex flex-col md:flex-row items-start justify-between gap-6">

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,82 +5,10 @@
 
 {% block content %}
 
-<section id="rc-hero" class="rc-hero rc-hero--dashboard" role="region" aria-labelledby="rc-hero-title">
-  <div class="rc-hero-inner">
-    <h1 id="rc-hero-title" class="rc-hero-title">Rules Central</h1>
-    <p class="rc-hero-subtitle">
-      Real-time insights and streamlined workflows
-    </p>
-  </div>
-</section>
-
-<header class="rc-dashboard-header rc-container" aria-labelledby="dashboard-title">
-  <div class="rc-dashboard-header-inner">
-    <div class="rc-dashboard-greeting">
-      <h2 id="dashboard-title" class="rc-dashboard-title">Overview Dashboard</h2>
-      <p class="rc-dashboard-subtitle">
-        Welcome back, {{ current_user.username if current_user.is_authenticated else 'Guest' }}!
-      </p>
-    </div>
-    
-    <div class="rc-dashboard-meta">
-      <div class="rc-dashboard-time">
-        <svg class="rc-dashboard-time-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-        </svg>
-        <time id="current-time" class="rc-dashboard-time-text"
-              datetime="{{ now.isoformat() if now else '' }}">
-          {{ now.strftime('%I:%M %p') if now else '' }}
-        </time>
-      </div>
-    </div>
-  </div>
-</header>
-
-<section id="metrics" class="rc-container rc-section rc-metrics" aria-labelledby="metrics-heading">
-  <div class="rc-section-head">
-    <h2 id="metrics-heading" class="rc-section-title">
-      <svg class="rc-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
-      </svg>
-      Key Metrics
-    </h2>
-    <div class="rc-section-sub">
-      Last updated: {{ last_updated.strftime('%b %d, %Y %I:%M %p') if last_updated else "—" }}
-    </div>
-  </div>
-</section>
-
-<section id="recent-activity" class="rc-container rc-section rc-activity">
-  <div class="rc-section-head">
-    <h2 class="rc-section-title">
-      <svg class="rc-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0zm-3 8h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
-      </svg>
-      Recent Activity
-    </h2>
-  </div>
-  
-  <div class="rc-card rc-activity-list">
-    {% if recent_activity %}
-      <ul class="rc-activity-items">
-        {% for activity in recent_activity %}
-          <li class="rc-activity-item">
-            <div class="rc-activity-content">
-              <time class="rc-activity-time" datetime="{{ activity.timestamp.isoformat() if activity.timestamp else '' }}">
-                {{ activity.timestamp|humanize if activity.timestamp else '' }}
-              </time>
-            </div>
-          </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <div class="rc-empty-state">
-        No recent activity
-      </div>
-    {% endif %}
-  </div>
-</section>
+{% include "partials/index_hero.html" %}
+{% include "partials/index_dashboard_header.html" %}
+{% include "partials/index_metrics.html" %}
+{% include "partials/index_recent_activity.html" %}
 
 {% endblock content %}
 

--- a/templates/partials/index_dashboard_header.html
+++ b/templates/partials/index_dashboard_header.html
@@ -1,0 +1,22 @@
+<header class="rc-dashboard-header rc-container" aria-labelledby="dashboard-title">
+  <div class="rc-dashboard-header-inner">
+    <div class="rc-dashboard-greeting">
+      <h2 id="dashboard-title" class="rc-dashboard-title">Overview Dashboard</h2>
+      <p class="rc-dashboard-subtitle">
+        Welcome back, {{ current_user.username if current_user.is_authenticated else 'Guest' }}!
+      </p>
+    </div>
+
+    <div class="rc-dashboard-meta">
+      <div class="rc-dashboard-time">
+        <svg class="rc-dashboard-time-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+        <time id="current-time" class="rc-dashboard-time-text"
+              datetime="{{ now.isoformat() if now else '' }}">
+          {{ now.strftime('%I:%M %p') if now else '' }}
+        </time>
+      </div>
+    </div>
+  </div>
+</header>

--- a/templates/partials/index_hero.html
+++ b/templates/partials/index_hero.html
@@ -1,0 +1,8 @@
+<section id="rc-hero" class="rc-hero rc-hero--dashboard" role="region" aria-labelledby="rc-hero-title">
+  <div class="rc-hero-inner">
+    <h1 id="rc-hero-title" class="rc-hero-title">Rules Central</h1>
+    <p class="rc-hero-subtitle">
+      Real-time insights and streamlined workflows
+    </p>
+  </div>
+</section>

--- a/templates/partials/index_metrics.html
+++ b/templates/partials/index_metrics.html
@@ -1,0 +1,13 @@
+<section id="metrics" class="rc-container rc-section rc-metrics" aria-labelledby="metrics-heading">
+  <div class="rc-section-head">
+    <h2 id="metrics-heading" class="rc-section-title">
+      <svg class="rc-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+      </svg>
+      Key Metrics
+    </h2>
+    <div class="rc-section-sub">
+      Last updated: {{ last_updated.strftime('%b %d, %Y %I:%M %p') if last_updated else "—" }}
+    </div>
+  </div>
+</section>

--- a/templates/partials/index_recent_activity.html
+++ b/templates/partials/index_recent_activity.html
@@ -1,0 +1,30 @@
+<section id="recent-activity" class="rc-container rc-section rc-activity">
+  <div class="rc-section-head">
+    <h2 class="rc-section-title">
+      <svg class="rc-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0zm-3 8h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
+      </svg>
+      Recent Activity
+    </h2>
+  </div>
+
+  <div class="rc-card rc-activity-list">
+    {% if recent_activity %}
+      <ul class="rc-activity-items">
+        {% for activity in recent_activity %}
+          <li class="rc-activity-item">
+            <div class="rc-activity-content">
+              <time class="rc-activity-time" datetime="{{ activity.timestamp.isoformat() if activity.timestamp else '' }}">
+                {{ activity.timestamp|humanize if activity.timestamp else '' }}
+              </time>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <div class="rc-empty-state">
+        No recent activity
+      </div>
+    {% endif %}
+  </div>
+</section>


### PR DESCRIPTION
### Motivation
- Improve maintainability and reuse by extracting the home dashboard sections into independent partial templates. 
- Surface the change in docs so contributors understand the new template composition approach.

### Description
- Replace the inline dashboard markup in `templates/index.html` with includes for `partials/index_hero.html`, `partials/index_dashboard_header.html`, `partials/index_metrics.html`, and `partials/index_recent_activity.html`.
- Add four new partial templates under `templates/partials/` to encapsulate hero, header, metrics, and recent-activity sections.
- Update `README.md` to note that the index uses partials and add a short mention in `routes/core.py` docstring about the dashboard template composition.
- Document the template composition approach in `templates/documentation.html` with an example include for contributors.

### Testing
- Ran the Python test suite with `pytest -v` and all tests passed: `25 passed in 0.51s`.
- No automated frontend tests were required for these templating changes and no database migrations are needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982b496901883339dbb591d517ff393)