### PR TITLE
feat: add rooms UI prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,21 @@ modules:
 - `navigation.js` – mobile menu and user dropdowns
 - `dashboard.js` – realtime clock, metrics refresh and charts
 
+## UI Prototype: Rooms Experience
+
+This repository now includes a standalone UI prototype in `rooms.html` with a
+companion `itinerary.html` page. The rooms prototype demonstrates:
+
+- More prominent navigation with icons and a compact dropdown menu
+- Search and filter controls grouped together for a clearer flow
+- A simplified statistics section with focused cards and a chart placeholder
+- Larger room cards with feature badges (e.g., Balcony vs Interior)
+- Grouped quick actions with larger touch targets and tooltips
+- A compact modal layout with clearer calls-to-action
+
+Open `rooms.html` directly in your browser to review the interaction and layout
+changes.
+
 ### Testing Checklist
 
 1. `pytest -v`

--- a/itinerary.html
+++ b/itinerary.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Itinerary</title>
+  <style>
+    body{font-family:Inter,system-ui,sans-serif;margin:0;background:#f5f7fb;color:#0f172a}
+    main{width:min(900px,calc(100% - 2rem));margin:3rem auto;background:#fff;border:1px solid #dbe2ec;border-radius:14px;padding:1.2rem}
+    a{color:#1d4ed8}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Itinerary</h1>
+    <p>This page is linked from the enhanced navigation in <a href="rooms.html">Rooms</a>.</p>
+  </main>
+</body>
+</html>

--- a/rooms.html
+++ b/rooms.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rooms Dashboard</title>
+  <style>
+    :root {
+      --bg: #f5f7fb;
+      --surface: #ffffff;
+      --text: #1e293b;
+      --muted: #5b6472;
+      --line: #dbe2ec;
+      --primary: #2563eb;
+      --primary-soft: #dbeafe;
+      --good: #047857;
+      --warn: #b45309;
+      --shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+      --radius: 14px;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.5;
+    }
+
+    a { color: inherit; text-decoration: none; }
+
+    .container {
+      width: min(1120px, calc(100% - 2rem));
+      margin-inline: auto;
+    }
+
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 30;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.92);
+      backdrop-filter: blur(6px);
+    }
+
+    .nav-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      min-height: 72px;
+      gap: 1rem;
+    }
+
+    .brand {
+      font-weight: 800;
+      font-size: 1.12rem;
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+    }
+
+    .brand .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--primary);
+      box-shadow: 0 0 0 5px var(--primary-soft);
+    }
+
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: .35rem;
+      flex-wrap: wrap;
+    }
+
+    .nav-item,
+    .nav-summary {
+      display: inline-flex;
+      align-items: center;
+      gap: .45rem;
+      padding: .55rem .8rem;
+      border-radius: 10px;
+      color: #334155;
+      font-weight: 600;
+      border: 1px solid transparent;
+    }
+
+    .nav-item.active {
+      background: var(--primary-soft);
+      color: #1d4ed8;
+      border-color: #bfd7ff;
+    }
+
+    details.nav-dropdown {
+      position: relative;
+    }
+
+    .menu {
+      position: absolute;
+      right: 0;
+      top: calc(100% + 8px);
+      width: 220px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+      padding: .4rem;
+    }
+
+    .menu a {
+      display: block;
+      padding: .55rem .65rem;
+      border-radius: 9px;
+    }
+
+    .menu a:hover,
+    .menu a:focus-visible { background: #f1f5f9; }
+
+    main { padding: 1.25rem 0 2.2rem; }
+
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .search-row {
+      display: grid;
+      grid-template-columns: 1fr auto auto;
+      gap: .65rem;
+      align-items: stretch;
+    }
+
+    .search-input {
+      width: 100%;
+      border: 1px solid #cbd5e1;
+      border-radius: 12px;
+      font-size: 1rem;
+      padding: .8rem .9rem;
+      min-height: 48px;
+    }
+
+    .btn {
+      min-height: 48px;
+      border: 1px solid #cbd5e1;
+      background: #fff;
+      border-radius: 12px;
+      font-weight: 700;
+      color: #334155;
+      padding: .75rem .95rem;
+      cursor: pointer;
+    }
+
+    .btn.primary {
+      background: var(--primary);
+      color: #fff;
+      border-color: #1d4ed8;
+    }
+
+    .section-heading {
+      display: flex;
+      justify-content: space-between;
+      align-items: end;
+      gap: 1rem;
+      margin-bottom: .7rem;
+    }
+
+    .section-heading h2 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .section-heading p {
+      margin: 0;
+      color: var(--muted);
+      font-size: .92rem;
+    }
+
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: .8rem;
+    }
+
+    .stat-card {
+      border: 1px solid #d8e0eb;
+      border-radius: 12px;
+      padding: .8rem;
+      background: #fcfdff;
+    }
+
+    .stat-card h3 { margin: 0; font-size: .88rem; color: #475569; }
+    .stat-value { font-size: 1.45rem; font-weight: 800; margin-top: .2rem; }
+
+    .chart {
+      margin-top: .7rem;
+      border: 1px solid #d8e0eb;
+      border-radius: 12px;
+      background: linear-gradient(180deg, #eef5ff, #f8fbff);
+      min-height: 140px;
+      padding: 1rem;
+      display: grid;
+      place-items: center;
+      color: #1e40af;
+      font-weight: 700;
+    }
+
+    .rooms-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+      gap: .95rem;
+    }
+
+    .room-card {
+      border: 1px solid #d8e0eb;
+      border-radius: 14px;
+      background: var(--surface);
+      padding: .9rem;
+      display: grid;
+      gap: .6rem;
+      transition: transform .18s ease, box-shadow .18s ease;
+    }
+
+    .room-card:hover,
+    .room-card:focus-within {
+      transform: translateY(-3px);
+      box-shadow: 0 12px 24px rgba(30, 41, 59, .14);
+    }
+
+    .room-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+      gap: .5rem;
+    }
+
+    .badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: .35rem;
+    }
+
+    .badge {
+      font-size: .75rem;
+      font-weight: 700;
+      padding: .2rem .45rem;
+      border-radius: 999px;
+      border: 1px solid;
+    }
+
+    .badge.balcony { background: #ecfeff; color: #155e75; border-color: #a5f3fc; }
+    .badge.interior { background: #fef3c7; color: #92400e; border-color: #fde68a; }
+
+    .meta { color: var(--muted); font-size: .9rem; }
+
+    .quick-actions {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
+    }
+
+    .action-group h3 { margin: 0 0 .55rem; font-size: .94rem; }
+
+    .action-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: .55rem;
+    }
+
+    .action-btn {
+      min-height: 46px;
+      padding: .65rem .85rem;
+      border-radius: 11px;
+      border: 1px solid #cbd5e1;
+      background: #fff;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .assist { background: #f8fafc; }
+
+    .modal-wrap {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.35);
+      display: grid;
+      place-items: center;
+      padding: 1rem;
+    }
+
+    .modal {
+      width: min(460px, 100%);
+      border-radius: 14px;
+      border: 1px solid #d6deea;
+      background: #fff;
+      box-shadow: 0 24px 40px rgba(15, 23, 42, 0.24);
+      padding: 1rem;
+      display: grid;
+      gap: .85rem;
+    }
+
+    .cta-row {
+      display: flex;
+      justify-content: end;
+      gap: .6rem;
+    }
+
+    @media (max-width: 860px) {
+      .stats-grid { grid-template-columns: 1fr; }
+      .quick-actions { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 680px) {
+      .search-row { grid-template-columns: 1fr; }
+      .nav-row { align-items: start; flex-direction: column; padding-block: .6rem; }
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar" role="banner">
+    <nav class="container nav-row" aria-label="Main navigation">
+      <a href="#" class="brand" aria-label="Home"><span class="dot" aria-hidden="true"></span>Harbor Hotel</a>
+      <div class="nav-links">
+        <a class="nav-item active" href="rooms.html" aria-current="page">🏨 Rooms</a>
+        <a class="nav-item" href="itinerary.html">🧳 Itinerary</a>
+        <a class="nav-item" href="#">📊 Reports</a>
+        <details class="nav-dropdown">
+          <summary class="nav-summary">⚙️ More</summary>
+          <div class="menu" role="menu" aria-label="More pages">
+            <a href="#" role="menuitem">Guests</a>
+            <a href="#" role="menuitem">Housekeeping</a>
+            <a href="#" role="menuitem">Billing</a>
+          </div>
+        </details>
+      </div>
+    </nav>
+  </header>
+
+  <main class="container">
+    <section class="panel" aria-labelledby="search-title">
+      <div class="section-heading">
+        <h1 id="search-title">Find a room quickly</h1>
+        <p>Use search + filters together for faster results.</p>
+      </div>
+      <form class="search-row" role="search" aria-label="Search rooms">
+        <input class="search-input" type="search" placeholder="Search by room number, guest name, or location" aria-label="Search rooms" />
+        <button type="button" class="btn" aria-label="Open filters">Filter ▾</button>
+        <button type="submit" class="btn primary">Search</button>
+      </form>
+    </section>
+
+    <section class="panel" aria-labelledby="overview-title">
+      <div class="section-heading">
+        <h2 id="overview-title">Statistics overview</h2>
+        <p>Focus on occupancy, cleaning status, and check-ins.</p>
+      </div>
+      <div class="stats-grid">
+        <article class="stat-card" aria-label="Occupied rooms"><h3>Occupied</h3><div class="stat-value">32</div></article>
+        <article class="stat-card" aria-label="Ready rooms"><h3>Ready</h3><div class="stat-value">18</div></article>
+        <article class="stat-card" aria-label="Pending cleaning"><h3>Needs Cleaning</h3><div class="stat-value">7</div></article>
+      </div>
+      <div class="chart" role="img" aria-label="Simple occupancy trend chart">Occupancy trend chart (7 days)</div>
+    </section>
+
+    <section class="panel" aria-labelledby="rooms-title">
+      <div class="section-heading">
+        <h2 id="rooms-title">Room cards</h2>
+        <p>Bigger cards, clearer feature labels, and more spacing.</p>
+      </div>
+      <div class="rooms-grid">
+        <article class="room-card" tabindex="0" aria-label="Room 401, balcony room">
+          <div class="room-head">
+            <strong>Room 401</strong>
+            <div class="badges"><span class="badge balcony">Balcony</span></div>
+          </div>
+          <div class="meta">Ocean wing · King bed · Check-out 11:00 AM</div>
+        </article>
+        <article class="room-card" tabindex="0" aria-label="Room 217, interior room">
+          <div class="room-head">
+            <strong>Room 217</strong>
+            <div class="badges"><span class="badge interior">Interior</span></div>
+          </div>
+          <div class="meta">Central hall · Queen bed · Early check-in ready</div>
+        </article>
+        <article class="room-card" tabindex="0" aria-label="Room 318, balcony room">
+          <div class="room-head">
+            <strong>Room 318</strong>
+            <div class="badges"><span class="badge balcony">Balcony</span></div>
+          </div>
+          <div class="meta">Garden side · Double bed · Housekeeping in progress</div>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel" aria-labelledby="actions-title">
+      <div class="section-heading">
+        <h2 id="actions-title">Quick actions</h2>
+        <p>Grouped for discoverability with larger touch targets.</p>
+      </div>
+      <div class="quick-actions">
+        <article class="action-group" aria-label="Ordering actions">
+          <h3>Ordering</h3>
+          <div class="action-list">
+            <button class="action-btn" title="Request room service for selected room">🍽️ Room Service</button>
+            <button class="action-btn" title="Send laundry pickup request">🧺 Laundry Pickup</button>
+          </div>
+        </article>
+        <article class="action-group" aria-label="Assistance actions">
+          <h3>Assistance</h3>
+          <div class="action-list">
+            <button class="action-btn assist" title="Call front desk for immediate help">📞 Front Desk</button>
+            <button class="action-btn assist" title="Create a maintenance ticket">🛠️ Maintenance</button>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <aside class="modal-wrap" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal">
+      <h2 id="modal-title">Upcoming check-in: Room 401</h2>
+      <p>Guest arrives in 20 minutes. Confirm room readiness and send the welcome checklist.</p>
+      <div class="cta-row">
+        <button class="btn">Later</button>
+        <button class="btn primary">Start check-in</button>
+      </div>
+    </div>
+  </aside>
+</body>
+</html>

--- a/routes/core.py
+++ b/routes/core.py
@@ -9,6 +9,7 @@ This module organizes all application routes into logical blueprints with:
 - CSRF protection
 - Structured API responses
 - Home dashboard template composition via partials.
+- Documentation references for standalone UI prototypes (e.g., rooms/itinerary).
 All route handlers document inputs and outputs per the style guide in
 ``AGENTS.md``.
 """

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -215,6 +215,20 @@
             You can also toggle a compact view with the new density button in the hierarchy viewer.
           </p>
         </div>
+        <div class="bg-gradient-to-r from-sky-500/10 to-blue-500/10 rounded-xl p-6 border border-sky-500/20 mt-6">
+          <div class="flex items-center gap-2 mb-3">
+            <svg class="w-5 h-5 text-sky-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M6 12h12M9 17h6"/>
+            </svg>
+            <h4 class="font-semibold text-sky-300">Rooms UI Prototype</h4>
+          </div>
+          <p class="text-gray-200">
+            A standalone UI prototype is available at <code>rooms.html</code> with a companion
+            <code>itinerary.html</code> page. It demonstrates stronger navigation hierarchy,
+            grouped quick actions, larger room cards, and improved search/filter flow.
+          </p>
+        </div>
+
         <div class="bg-gradient-to-r from-emerald-500/10 to-green-500/10 rounded-xl p-6 border border-emerald-500/20 mt-6">
           <div class="flex items-center gap-2 mb-3">
             <svg class="w-5 h-5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
### Motivation

- Provide a standalone UI prototype that demonstrates the requested UX improvements (clearer navigation hierarchy, grouped search/filters, simplified stats, larger room cards with feature badges, grouped quick actions, and a compact modal). 
- Surface the prototype in project documentation so reviewers can quickly inspect the visual changes and iterate on layout and accessibility.

### Description

- Add a new standalone prototype page `rooms.html` and a linked companion `itinerary.html` to exercise the updated UX patterns. 
- Update `README.md` and `templates/documentation.html` to document the prototype and note where to find the pages. 
- Add a short note to the `routes/core.py` module docstring to reference standalone UI prototypes. 
- No database or migration changes were made.

### Testing

- Run `pytest -v` and all tests passed (`25 passed`), see the output included in the PR. 
- A full-page screenshot of the prototype was captured for review at `browser:/tmp/codex_browser_invocations/d1e0fa6295495fe7/artifacts/artifacts/rooms-ui.png`. 
- No migrations were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8fed69e483338f2c46edf80d02bd)